### PR TITLE
MsgBox Code Examples Second Attempt

### DIFF
--- a/docs/commands/MsgBox.htm
+++ b/docs/commands/MsgBox.htm
@@ -198,27 +198,41 @@ else
 <h3>Related</h3>
 <p><a href="InputBox.htm">InputBox</a>, <a href="FileSelectFile.htm">FileSelectFile</a>, <a href="FileSelectFolder.htm">FileSelectFolder</a>, <a href="ToolTip.htm">ToolTip</a>, <a href="Gui.htm">GUI</a></p>
 <h3>Example</h3>
-<pre class="NoIndent">MsgBox This is the 1-parameter method. Commas (,) do not need to be escaped.
-MsgBox, 4, , This is the 3-parameter method. Commas (,) do not need to be escaped.
+<h4>Function Syntax:</h4><pre class="NoIndent">MsgBox("This is the 1-parameter method. If only one parameter is passed, the first parameter becomes the message.")
+
+MsgBox(64, "3-parameter method", "The first parameter determins the type of message box.`n" 
+	. "The second parameter becomes the window title.`n"
+	. "The third parameter is displayed as the message.")
+
+MsgBox(4, "", "Do you want to continue? (Press YES or NO)")
+if A_MsgBoxResult = "No"
+    return
+	
+MsgBox(4, "4-parameter method", "this MsgBox will time out in 5 seconds.  Continue?", 5)
+if A_MsgBoxResult = "Timeout"
+    MsgBox("You didn't press YES or NO within the 5-second period.")
+else if A_MsgBoxResult = "No"
+    return</pre><pre class="NoIndent"><em>; Include a variable and perform a math calculation in the message.</em>
+var := 10
+Msgbox("The initial value is: " var)
+MsgBox("The result is: " var * 2)</pre>
+<h4>Command Syntax:</h4><pre class="NoIndent">MsgBox This is the 1-parameter method. Commas (,) do not need to be escaped.
+
+MsgBox, 64
+	, 3-parameter method
+	, This is the 3-parameter method. Commas (,) do not need to be escaped.
+	
 MsgBox, 4, , Do you want to continue? (Press YES or NO)
 if A_MsgBoxResult = "No"
     return
-MsgBox, 4, , 4-parameter method: this MsgBox will time out in 5 seconds.  Continue?, 5
+	
+MsgBox, 4,,  4-parameter method: this MsgBox will time out in 5 seconds.  Continue?, 5
 if A_MsgBoxResult = "Timeout"
     MsgBox You didn't press YES or NO within the 5-second period.
 else if A_MsgBoxResult = "No"
-    return
-    
-<em>; By preceding any parameter with &quot;% &quot;, it becomes an expression. In the following example,
-; math is performed, an array element is accessed, and a function is called.  All of these
-; items are concatenated via the &quot;.&quot; operator to form a single string displayed by MsgBox:</em>
-MsgBox % &quot;New width for object #&quot; . A_Index . &quot; is: &quot; . RestrictWidth(ObjectWidth%A_Index% * ScalingFactor)
-
-<em>; The following example alerts the user that a MsgBox is going to steal focus (in case the user is typing).</em>
-SplashTextOn,,, A MsgBox is about to appear.
-Sleep 3000
-SplashTextOff
-MsgBox The backup process has completed.</pre>
-
+    return</pre><pre class="NoIndent"><em>;Include a variable in the message.</em>
+var := 10
+MsgBox The initial value is: %var	<em>;The preciding % enables to yield the contents of the variable.</em>
+MsgBox % "The result is: " var * 2	<em>;By preceding any parameter with "% ", it becomes an expression.</em></pre>
 </body>
 </html>


### PR DESCRIPTION
Removed:
- the example using RestrictWidth() since it is not a working example.
- the one with SplashTextOn since it does not introduce a functionality of MsgBox not covered by other examples.

Added:
- examples for function syntax.
- an example demonstrates how to include a variable and perform a calculation with it.
