### PR TITLE
Remove reference to command functions:

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -269,7 +269,5 @@ path-to-the-currently-running-AutoHotkey.exe\Lib\  <em>; Standard library.</em><
 <p><strong><a name="ACos"></a>ACos(Number)</strong>: Returns the arccosine (the number whose cosine is <em>Number</em>) in radians. If <em>Number</em> is less than -1 or greater than 1, the function yields a blank result (empty string).</p>
 <p><strong><a name="ATan"></a>ATan</strong><strong>(Number)</strong>: Returns the arctangent (the number whose tangent is <em>Number</em>) in radians.</p>
 <p><strong>Note:</strong> To convert a radians value to degrees, multiply it by 180/pi (approximately 57.29578). To convert a degrees value to radians, multiply it by pi/180 (approximately 0.01745329252). The value of pi (approximately 3.141592653589793) is 4 times the arctangent of 1.</p>
-<h3>Other Functions</h3>
-<p><a href="http://file.autohotkey.net/Titan/functions.html">Titan's Command Functions</a>: Provides a callable function for each AutoHotkey command that has an OutputVar. This library can be included in any script via <a href="commands/_Include.htm">#Include</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
as of v2, all commands can be called as functions without this lib.
