### PR TITLE
Out-of-date parameter description in RegisterCallback() page.

### DIFF
--- a/docs/commands/RegisterCallback.htm
+++ b/docs/commands/RegisterCallback.htm
@@ -34,7 +34,7 @@
   <dd><p>The number of parameters that <em>Address</em>'s caller will pass to it. If entirely omitted, it defaults to the number of mandatory parameters in the <a href="../Functions.htm#define">definition</a> of <em>FunctionName</em>. In either case, ensure that the caller passes exactly this number of parameters.</p></dd>
 
   <dt>EventInfo</dt>
-  <dd><p>An integer between 0 and 4294967295 that <em>FunctionName</em> will see in <a href="../Variables.htm#EventInfo">A_EventInfo</a> whenever it is called via this <em>Address</em>. This is useful when <em>FunctionName</em> is called by more than one <em>Address</em>. If omitted, it defaults to <em>Address</em>. Note: Unlike other global settings, the <a href="../misc/Threads.htm">current thread</a>'s A_EventInfo is not disturbed by the <a href="#Fast">fast mode</a>.</p></dd>
+  <dd><p>A <a href="../Variables.htm#PtrSize">pointer-sized</a> integer, equivalent to Int or Int64 depending on whether the exe running the script is 32-bit or 64-bit, that <em>FunctionName</em> will see in <a href="../Variables.htm#EventInfo">A_EventInfo</a> whenever it is called via this <em>Address</em>. This is useful when <em>FunctionName</em> is called by more than one <em>Address</em>. If omitted, it defaults to <em>Address</em>. Note: Unlike other global settings, the <a href="../misc/Threads.htm">current thread</a>'s A_EventInfo is not disturbed by the <a href="#Fast">fast mode</a>.</p></dd>
 
 </dl>
 


### PR DESCRIPTION
See [this topic](http://www.autohotkey.com/forum/viewtopic.php?p=516858#516858) for reference.

The A_EventInfo parameter is described as a 32-bit number in the documentation, while it is actually defined as a UINT_PTR, which is pointer-sized.
