### PR TITLE
Ahk2Exe now defaults to ANSI for BOM-less scripts

### DIFF
--- a/docs/Scripts.htm
+++ b/docs/Scripts.htm
@@ -139,7 +139,6 @@ Usage:
 </ol>
 <p>Notes:</p>
 <ul>
-  <li>BOM-less scripts are interpreted as UTF-8, like the Unicode build of AutoHotkey_L. This means that you have to <strong>save your script as UTF-8</strong> if it contains non-ASCII characters.</li>
   <li>Compiling does not typically improve the performance of a script.</li>
   <li>As of v1.1.01, password protection and the /NoDecompile switch are not supported.</li>
   <li>If <a href="http://www.matcode.com/mpress.htm">mpress.exe</a> is present in the &quot;Compiler&quot; subfolder where AutoHotkey was installed, it is used to compress the script executable, unless it is disabled via <code>/mpress 0</code> or the GUI setting. This also compresses the script source code (minus any comments), which can otherwise be extracted from the exe file using a PE resource editor.</li>
@@ -193,7 +192,6 @@ Usage:
 <h2 id="cp">Script File Codepage <span class="ver">[AHK_L 51+]</span></h2>
 <p>The characters a script file may contain are restricted by the codepage used to load the file.</p>
 <ul>
-  <li>Source files for compiled scripts <b class="red">must</b> be encoded as <b>UTF-8</b> or contain only ASCII characters.</li>
   <li>If the file begins with a UTF-8 or UTF-16 (LE) byte order mark, the appropriate codepage is used and the <a href="#CPn">/CP<i>n</i></a> switch is ignored.</li>
   <li>If the <a href="#CPn">/CP<i>n</i></a> switch is passed on the command-line, codepage <i>n</i> is used. For a list of valid numeric codepage identifiers, see <a href="http://msdn.microsoft.com/en-us/library/dd317756.aspx">MSDN</a>.</li>
   <li>In all other cases, the system default ANSI codepage is used.</li>


### PR DESCRIPTION
The documentation for Ahk2Exe was not updated when the default was [changed back](https://github.com/fincs/Ahk2Exe/commit/9603f9399ab9d3db8c65479ddb2c6f21856fc4f8) to ANSI for BOM-less scripts (like the Unicode builds). I just fixed it.
