### PR TITLE
Consistent formatting of examples

### DIFF
--- a/docs/Variables.htm
+++ b/docs/Variables.htm
@@ -716,8 +716,10 @@ if A_OSVersion in WIN_NT4,WIN_95,WIN_98,WIN_ME  <em>; Note: No spaces around com
     <td><p>The width and height of the primary monitor, in pixels (e.g. 1024 and 768).</p>
       <p>To discover the dimensions of other monitors in a multi-monitor system, use <a href="commands/SysGet.htm">SysGet</a>.</p>
       <p>To instead discover the width and height of the entire desktop (even if it spans multiple monitors), use the following example (but on Windows 95/NT, both of the below variables will be set to 0):<br>
-      <a href="commands/SysGet.htm">SysGet</a>, VirtualWidth, 78<br>
-      <a href="commands/SysGet.htm">SysGet</a>, VirtualHeight, 79</p>
+<pre>
+<a href="commands/SysGet.htm">SysGet</a>, VirtualWidth, 78
+<a href="commands/SysGet.htm">SysGet</a>, VirtualHeight, 79
+</pre>
     <p>In addition, use <a href="commands/SysGet.htm">SysGet</a> to discover the work area of a monitor, which can be smaller than the monitor's total area because the taskbar and other registered desktop toolbars are excluded.</p></td>
   </tr>
   <tr id="IPAddress">
@@ -738,12 +740,14 @@ if A_OSVersion in WIN_NT4,WIN_95,WIN_98,WIN_ME  <em>; Note: No spaces around com
     A_CaretY</td>
     <td><p>The current X and Y coordinates of the caret (text insertion point). The coordinates are relative to the active window unless <a href="commands/CoordMode.htm">CoordMode</a> is used to make them relative to the entire screen. If there is no active window or the caret position cannot be determined, these variables are blank.</p>
       <p>The following script allows you to move the caret around to see its current position displayed in an auto-update tooltip. Note that some windows (e.g. certain versions of MS Word) report the same caret position regardless of its actual position.</p>
-      <p>#Persistent<br>
-        SetTimer, WatchCaret, 100<br>
-        return<br>
-        WatchCaret:<br>
-        ToolTip, X%A_CaretX% Y%A_CaretY%, A_CaretX, A_CaretY - 20<br>
-      return</p>
+<pre>
+#Persistent
+SetTimer, WatchCaret, 100
+return
+WatchCaret:
+  ToolTip, X%A_CaretX% Y%A_CaretY%, A_CaretX, A_CaretY - 20
+return
+</pre>
       <p>If the contents of these variables are fetched repeatedly at a high frequency (i.e. every 500 ms or faster), the user's ability to double-click will probably be disrupted. There is no known workaround.</p></td>
   </tr>
   <tr>


### PR DESCRIPTION
Some code-examples are set within `<pre>` tags (for example: `AIsAdmin`), whereas others aren't (for example: `ACaretX`)

_Done:_ Set all code examples into `<pre>` tags

---

See:
https://trello.com/card/consistent-formatting-of-examples-on-page-variables-htm/4ff142712c442e040466599d/20
