### PR TITLE
Wrong variable name in example for static variables

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -136,7 +136,7 @@ MsgBox % Join("`n", <b class="blue">substrings*</b>)</pre>
     <strong>static</strong> LoggedLines = 0
     LoggedLines += 1  <em>; Maintain a tally locally (its value is remembered between calls).</em>
     global LogFileName
-    FileAppend, %LineCount%: %TextToLog%`n, %LogFileName%
+    FileAppend, %LoggedLines%: %TextToLog%`n, %LogFileName%
 }</pre>
 <p><a name="InitStatic"></a><strong>Static Initializers</strong>: In versions prior to 1.0.46, all static variables started off blank; so the only way to detect that one was being used for the first time was to check whether it was blank. In v1.0.46+, a static variable may be initialized to something other than <code>&quot;&quot;</code> by following it with <code>:=</code> or <code>=</code> followed by one of the following: true, false, a literal integer, a literal floating point number, or a literal/quoted string such as <code>&quot;fox&quot;</code>. For example: <code>static X:=0, Y:=&quot;fox&quot;</code>. Each static variable is initialized only once (before the script begins executing).</p>
 <p><span class="ver">[AHK_L 58+]:</span> <code>Static var := expression</code> is supported. All such expressions are evaluated immediately before the script's auto-execute section in the order they are encountered in the script.</p>


### PR DESCRIPTION
see: https://trello.com/card/bug-in-example-for-static-variables/4ff142712c442e040466599d/28
