### PR TITLE
Changed link to german help file

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -63,7 +63,7 @@
 <ul>
   <li><a href="AutoHotkey_L_Help.zip">English</a></li>
   <li><a href="http://cn.autohotkey.com/download/AutoHotkey_L_Help_CN.zip">Chinese</a> (中文)</li>
-  <li><a href="http://de.autohotkey.com/download/AutoHotkey_L_Help_DE.zip">German</a> (Deutsch)</li>
+  <li><a href="http://ragnar-f.github.com/download/AutoHotkey_L_Help_DE.zip">German</a> (Deutsch)</li>
 </ul>
 <p>Some older downloads are available in <a href="v/">the archives</a>.</p>
 <p>Source code is available for <a href="http://github.com/Lexikos/AutoHotkey_L">AutoHotkey_L</a> and <a href="http://github.com/fincs/Ahk2Exe">Ahk2Exe</a> via <a href="http://git-scm.com/">git</a> or http download at github.</p>


### PR DESCRIPTION
de.autohotkey.com is no longer available because of merging english and german forum. 
