### PR TITLE
Fixed broken links (case sensitive)

### DIFF
--- a/docs/ChangeLogHelp.htm
+++ b/docs/ChangeLogHelp.htm
@@ -26,7 +26,7 @@
 <p>Fixed <a href="commands/GuiControl.htm">GuiControl</a>/<a href="commands/GuiControlGet.htm">GuiControlGet</a>/<a href="commands/Gui.htm">Gui</a>/<a href="commands/PostMessage.htm">SendMessage</a> to work reliably even when they trigger a <a href="commands/RegisterCallback.htm">callback</a> or <a href="commands/OnMessage.htm">OnMessage</a> function. [thanks Lexikos]</p>
 <p>Fixed <a href="commands/RegExMatch.htm">RegExMatch()</a> not to produce too few replacements when an empty-string match is followed by a non-empty-string match.</p>
 <p>Changed <code>While()</code> to be recognized as a <a href="commands/While.htm">loop</a> rather than a <a href="Functions.htm">function</a>. [thanks Crash&amp;Burn]</p>
-<p>Improved <a href="commands/UrlDownloadToFile.htm">UrlDownloadToFile</a> to support FTP and Gopher. [thanks Lexikos]</p>
+<p>Improved <a href="commands/URLDownloadToFile.htm">UrlDownloadToFile</a> to support FTP and Gopher. [thanks Lexikos]</p>
 <p>Improved the <a href="commands/FileAppend.htm#stdout">stdout/asterisk mode</a> of FileAppend to write immediately rather than lazily to standard output. [thanks Lexikos]</p>
 <p>Added full support for <code>if % expression</code>. [thanks kenomby]</p>
 <h2>1.0.48.03 - May 3, 2009</h2>
@@ -208,7 +208,7 @@
 <p>Fixed <a href="Functions.htm">functions</a> that call themselves and assign the result to one of their own <a href="Functions.htm#Locals">locals</a> (broken by v1.0.45). [thanks bjennings]</p>
 <p>Fixed crash of scripts containing <a href="misc/RegEx-QuickRef.htm">regular expressions</a> that have compile errors. [thanks PhiLho]</p>
 <p>Fixed <a href="commands/GuiControl.htm">GuiControl</a> not to convert <a href="commands/GuiControls.htm#Checkbox">checkboxes</a> into 3-state unless requested. [thanks JBensimon]</p>
-<p>Changed <a href="commands/UrlDownloadToFile.htm">UrlDownloadToFile</a> to announce a user-agent of &quot;AutoHotkey&quot; to the server rather than a blank string. [thanks jaco0646]</p>
+<p>Changed <a href="commands/URLDownloadToFile.htm">UrlDownloadToFile</a> to announce a user-agent of &quot;AutoHotkey&quot; to the server rather than a blank string. [thanks jaco0646]</p>
 <p>Improved <a href="Scripts.htm#continuation">continuation sections</a> to support semicolon comments inside the section via the option-word <em>Comments</em>.</p>
 <h2>1.0.45.02 - November 8, 2006</h2>
 <p>Fixed <a href="commands/StringLower.htm">StringUpper</a> and <a href="commands/StringLower.htm">StringLower</a> to work when OutputVar is the clipboard (broken by v1.0.45). [thanks songsoverruins]</p>

--- a/docs/commands/FileRead.htm
+++ b/docs/commands/FileRead.htm
@@ -55,7 +55,7 @@
 <p><a href="FileOpen.htm">FileOpen()</a> provides more advanced functionality than FileRead, such as reading or writing data at a specific location in the file without reading the entire file into memory. See <a href="../objects/File.htm">File Object</a> for a list of functions.</p>
 
 <h3>Related</h3>
-<p><a href="FileEncoding.htm">FileEncoding</a>, <a href="FileOpen.htm">FileOpen</a>/<a href="../objects/File.htm">File Object</a>, <a href="LoopReadFile.htm">file-reading loop</a>, <a href="FileReadLine.htm">FileReadLine</a>, <a href="FileGetSize.htm">FileGetSize</a>, <a href="FileAppend.htm">FileAppend</a>, <a href="IniRead.htm">IniRead</a>, <a href="Sort.htm">Sort</a>, <a href="UrlDownloadToFile.htm">UrlDownloadToFile</a></p>
+<p><a href="FileEncoding.htm">FileEncoding</a>, <a href="FileOpen.htm">FileOpen</a>/<a href="../objects/File.htm">File Object</a>, <a href="LoopReadFile.htm">file-reading loop</a>, <a href="FileReadLine.htm">FileReadLine</a>, <a href="FileGetSize.htm">FileGetSize</a>, <a href="FileAppend.htm">FileAppend</a>, <a href="IniRead.htm">IniRead</a>, <a href="Sort.htm">Sort</a>, <a href="URLDownloadToFile.htm">UrlDownloadToFile</a></p>
 
 <h3>Examples</h3>
 <pre class="NoIndent" id="ex1"><em>; Example #1: Read text file into OutputVar.</em>

--- a/docs/commands/Finally.htm
+++ b/docs/commands/Finally.htm
@@ -14,7 +14,7 @@
 
 <h1>Finally <span class="ver">[v1.1.14+]</span></h1>
 
-<p>Ensures that one or more statements (commands or expressions) are always executed after the execution of a <a href="try.htm">try</a> statement.</p>
+<p>Ensures that one or more statements (commands or expressions) are always executed after the execution of a <a href="Try.htm">try</a> statement.</p>
 
 <pre class="Syntax">Finally <i>Statement</i></pre>
 <pre class="Syntax" style="line-height: 100%">Finally

--- a/docs/commands/RegExMatch.htm
+++ b/docs/commands/RegExMatch.htm
@@ -83,7 +83,7 @@
 <p>AutoHotkey's regular expressions are implemented using Perl-compatible Regular Expressions (PCRE) from <a href="http://www.pcre.org/">www.pcre.org</a>.</p>
 <h3>Related</h3>
 <p><a href="RegExReplace.htm">RegExReplace()</a>, <a href="../misc/RegEx-QuickRef.htm">RegEx Quick Reference</a>, <a href="../misc/RegExCallout.htm">Regular Expression Callouts</a>, <a href="../Functions.htm#InStr">InStr()</a>, <a href="IfInString.htm">IfInString</a>, <a href="StringGetPos.htm">StringGetPos</a>, <a href="../Functions.htm#SubStr">SubStr()</a>, <a href="SetTitleMatchMode.htm#RegEx">SetTitleMatchMode RegEx</a>, <a href="http://www.autohotkey.com/forum/topic16164.html">Global matching and Grep (forum link)</a></p>
-<p>Common sources of text data: <a href="FileRead.htm">FileRead</a>, <a href="UrlDownloadToFile.htm">UrlDownloadToFile</a>, <a href="../misc/Clipboard.htm">Clipboard</a>, <a href="GuiControls.htm#Edit">GUI Edit controls</a></p>
+<p>Common sources of text data: <a href="FileRead.htm">FileRead</a>, <a href="URLDownloadToFile.htm">UrlDownloadToFile</a>, <a href="../misc/Clipboard.htm">Clipboard</a>, <a href="GuiControls.htm#Edit">GUI Edit controls</a></p>
 <h3>Examples</h3>
 <pre class="NoIndent">FoundPos := RegExMatch(&quot;xxxabc123xyz&quot;, &quot;abc.*xyz&quot;)  <em>; Returns 4, which is the position where the match was found.</em>
 FoundPos := RegExMatch(&quot;abc123123&quot;, &quot;123$&quot;)  <em>; Returns 7 because the $ requires the match to be at the end.</em>

--- a/docs/commands/RegExReplace.htm
+++ b/docs/commands/RegExReplace.htm
@@ -67,7 +67,7 @@
 <p>To learn the basics of regular expressions (or refresh your memory of pattern syntax), see the <a href="../misc/RegEx-QuickRef.htm">RegEx Quick Reference</a>.</p>
 <h3>Related</h3>
 <p><a href="RegExMatch.htm">RegExMatch()</a>, <a href="../misc/RegEx-QuickRef.htm">RegEx Quick Reference</a>, <a href="../misc/RegExCallout.htm">Regular Expression Callouts</a>, <a href="StringReplace.htm">StringReplace</a>, <a href="../Functions.htm#InStr">InStr()</a></p>
-<p>Common sources of text data: <a href="FileRead.htm">FileRead</a>, <a href="UrlDownloadToFile.htm">UrlDownloadToFile</a>, <a href="../misc/Clipboard.htm">Clipboard</a>, <a href="GuiControls.htm#Edit">GUI Edit controls</a></p>
+<p>Common sources of text data: <a href="FileRead.htm">FileRead</a>, <a href="URLDownloadToFile.htm">UrlDownloadToFile</a>, <a href="../misc/Clipboard.htm">Clipboard</a>, <a href="GuiControls.htm#Edit">GUI Edit controls</a></p>
 <h3>Examples</h3>
 <pre class="NoIndent">NewStr := RegExReplace(&quot;abc123123&quot;, &quot;123$&quot;, &quot;xyz&quot;)  <em>; Returns &quot;abc123xyz&quot; because the $ allows a match only at the end.</em>
 NewStr := RegExReplace(&quot;abc123&quot;, &quot;i)^ABC&quot;)  <em>; Returns &quot;123&quot; because a match was achieved via the case-insensitive option.</em>

--- a/docs/commands/index.htm
+++ b/docs/commands/index.htm
@@ -947,7 +947,7 @@
     <td>Applies a condition to the continuation of a Loop or For-loop.</td>
   </tr>
   <tr>
-    <td><a href="UrlDownloadToFile.htm">UrlDownloadToFile</a></td>
+    <td><a href="URLDownloadToFile.htm">UrlDownloadToFile</a></td>
     <td>Downloads a file from the Internet.</td>
   </tr>
   <tr>


### PR DESCRIPTION
> We should first explain exactly what we mean by "case sensitive URLs". Some Web servers (usually Unix servers) consider URLs to be case-sensitive. That is, they would treat each of the following URLs as referring to a different file:
> 
> ```
> http://www.example.com/mypage.html
> http://www.example.com/MyPage.html
> http://www.example.com/MYPAGE.html
> http://www.example.com/MYPAGE.HTML
> ```
> 
> If you visited `http://www.example.com/mypage.html` but the file was actually named "MyPage.html", these kinds of servers would display a "file not found" error.
> 
> Other Web servers (mostly Windows servers) would treat all these URLs as requests for the same file, because they use a file system that doesn't care about capitalization. Using an incorrectly capitalized link on these kinds of servers doesn't cause an error.
> 
> It's best to avoid this problem entirely by making sure that the capitalization of any URL links matches the capitalization of your file names, ensuring that your files work on any kind of server. However, if you have an existing site, these errors can be difficult to find.

Source: http://support.tigertech.net/case-sensitive

For example, GitHub runs a server of this type. As a result, the links fixed in this commit show the 404 error.

Also note that two UrlDownloadToFile html pages exist on ahkscript.org (<b>Url</b>DownloadToFile.htm and <b>URL</b>DownloadToFile.htm). The first one could be deleted if this pull request is merged.
