### PR TITLE
Update SciTE4AutoHotkey link

### DIFF
--- a/docs/AHKL_DBGPClients.htm
+++ b/docs/AHKL_DBGPClients.htm
@@ -17,7 +17,7 @@
 <p>Additional debugging features are supported via <a href="http://xdebug.org/docs-dbgp.php">DBGp</a>, a common debugger protocol for languages and debugger UI communication. See <a href="Scripts.htm#idebug">Interactive Debugging</a> for more details. Some UIs or "clients" known to be compatible with AutoHotkey are listed on this page.</p>
 
 <h2>SciTE4AutoHotkey</h2>
-<p><a href="http://www.autohotkey.net/~fincs/SciTE4AutoHotkey_3/web/">SciTE4AutoHotkey</a> is a free, <a href="http://www.scintilla.org/SciTE.html">SciTE</a>-based AutoHotkey script editor. In addition to DBGp support, it provides syntax highlighting, calltips/parameter info and auto-complete for AutoHotkey, and other useful editing features and scripting tools.</p>
+<p><a href="http://fincs.ahk4.net/scite4ahk/">SciTE4AutoHotkey</a> is a free, <a href="http://www.scintilla.org/SciTE.html">SciTE</a>-based AutoHotkey script editor. In addition to DBGp support, it provides syntax highlighting, calltips/parameter info and auto-complete for AutoHotkey, and other useful editing features and scripting tools.</p>
 <p>Debugging features include:</p>
 <ul>
   <li>Breakpoints.</li>
@@ -28,7 +28,7 @@
   <li>Inspect or edit variable contents.</li>
   <li>View structure of objects.</li>
 </ul>
-<p><a href="http://www.autohotkey.net/~fincs/SciTE4AutoHotkey_3/web/">http://www.autohotkey.net/~fincs/SciTE4AutoHotkey_3/web/</a></p>
+<p><a href="http://fincs.ahk4.net/scite4ahk/">http://fincs.ahk4.net/scite4ahk/</a></p>
 
 <h2>XDebugClient</h2>
 <p><a href="http://code.google.com/p/xdebugclient/">XDebugClient</a> is a simple open-source front-end DBGp client based on the <b>.NET Framework 2.0</b>. XDebugClient was originally designed for PHP with Xdebug, but a custom build compatible with AutoHotkey is available below.</p>


### PR DESCRIPTION
I just noticed the link to the SciTE4AutoHotkey website is outdated.
