### PR TITLE
Moved search link to config file

### DIFF
--- a/docs/static/config.xml
+++ b/docs/static/config.xml
@@ -2,6 +2,7 @@
 <config>
     <hdSearchTxt>Enter search term ...</hdSearchTxt>
     <hdSearchBtn>Search</hdSearchBtn>
+    <hdSearchLnk>'http://www.google.com/cse?cx=010629462602499112316:ywoq_rufgic&amp;q=' + query</hdSearchLnk>
     <sbContent>Content</sbContent>
     <sbIndex>Index</sbIndex>
     <ftLicense>License:</ftLicense>

--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -81,13 +81,13 @@ function AddContent()
 
     $('.header #search-btn').on('click', function() {
       var query = $(".header #q").val();
-      document.location = 'http://www.google.com/cse?cx=010629462602499112316:ywoq_rufgic&q=' + query;
+      document.location = eval(sessionStorage.getItem("hdSearchLnk"));
     });
 
     $('.header #search-form').on('submit', function(event) {
         event.preventDefault();
         var query = $(".header #q").val();
-        document.location = 'http://www.google.com/cse?cx=010629462602499112316:ywoq_rufgic&q=' + query;
+        document.location = eval(sessionStorage.getItem("hdSearchLnk"));
     });
 
     //


### PR DESCRIPTION
This allows non-english documentations to use their own specific search link on an easy way, since the cse search provided by commit #104 is for english content only.
