### PR TITLE
rm extra related link to "ComObjConnect"

### DIFF
--- a/docs/commands/ComObjConnect.htm
+++ b/docs/commands/ComObjConnect.htm
@@ -46,7 +46,7 @@
 <p>If the number of parameters is not known, a <a href="../Functions.htm#Variadic">variadic function</a> can be used.</p>
 
 <h3>Related</h3>
-<p><a href="ComObjCreate.htm">ComObjCreate</a>, <a href="ComObjGet.htm">ComObjGet</a>, <a href="ComObjActive.htm">ComObjActive</a>, <a href="ComObjConnect.htm">ComObjConnect</a>, <a href="ComObjError.htm">ComObjError</a>, <a href="http://msdn.microsoft.com/en-us/library/ccxe1xe6.aspx">WScript.ConnectObject (MSDN)</a></p>
+<p><a href="ComObjCreate.htm">ComObjCreate</a>, <a href="ComObjGet.htm">ComObjGet</a>, <a href="ComObjActive.htm">ComObjActive</a>, <a href="ComObjError.htm">ComObjError</a>, <a href="http://msdn.microsoft.com/en-us/library/ccxe1xe6.aspx">WScript.ConnectObject (MSDN)</a></p>
 
 <h3 id="Examples">Examples</h3>
 <pre class="NoIndent">


### PR DESCRIPTION
On every other COM page, none of them have a link directed to the same page.

> reduce confusion
