### PR TITLE
Code box improvements

### DIFF
--- a/docs/commands/ListView.htm
+++ b/docs/commands/ListView.htm
@@ -152,7 +152,7 @@ ExitApp</pre>
     if InStr(RetrievedText, &quot;some filter text&quot;)
         LV_Modify(A_Index, &quot;Select&quot;)  <em>; Select each row whose first field contains the filter-text.</em>
 }</pre>
-<p>To retrieve the widths of a ListView's columns -- for uses such as saving them to an INI file to be remembered beween sessions -- follow this example:</p>
+<p>To retrieve the widths of a ListView's columns -- for uses such as saving them to an INI file to be remembered between sessions -- follow this example:</p>
 <pre>Gui +LastFound
 Loop % LV_GetCount(&quot;Column&quot;)
 {

--- a/docs/static/config.xml
+++ b/docs/static/config.xml
@@ -7,4 +7,6 @@
     <sbIndex>Index</sbIndex>
     <ftLicense>License:</ftLicense>
     <ftExtra></ftExtra>
+    <cdSelectBtn>Select</cdSelectBtn>
+    <cdDownloadBtn>Download</cdDownloadBtn>
 </config>

--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -134,6 +134,81 @@ function AddContent()
     });
 
     //
+    // Add useful features for code boxes
+    //
+
+    // Show select and download buttons in lower right corner of a pre box
+
+    var divStyle = {fontSize: "11px", float: "right"};
+    var aStyle = {cursor: "pointer", color: $("a:link").css("color")};
+    var selectLink = $('<a id="selectCode">').text(sessionStorage.getItem("cdSelectBtn")).css(aStyle);
+    var downloadLink = $('<a id="downloadCode">').text(sessionStorage.getItem("cdDownloadBtn")).css(aStyle);
+
+    $('pre').each(function(index) {
+      if ($(this).is(".Syntax")) {
+        $.extend(divStyle, {marginTop: "-32px", marginRight: "7px"});
+        $(this).after($('<div>').css(divStyle).prepend(selectLink.clone()));
+      }
+      else {
+        $.extend(divStyle, {marginTop: "-28px", marginRight: "28px"});
+        $(this).after($('<div>').css(divStyle).prepend(selectLink.clone(), [' | ', downloadLink.clone()]));
+      }
+    });
+
+    // Select complete code when clicking
+
+    $('a#selectCode').each(function(index) {
+      $(this).on('click', function(e) {
+        var doc = document
+          , text = $(this).parent().prev('pre')[0]
+          , range, selection
+        ;
+        if (doc.body.createTextRange) {
+          range = document.body.createTextRange();
+          range.moveToElementText(text);
+          range.select();
+        } else if (window.getSelection) {
+          selection = window.getSelection();        
+          range = document.createRange();
+          range.selectNodeContents(text);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      });
+    });
+
+    // Download complete code when clicking
+
+    $('a#downloadCode').each(function(index) {
+      $(this).on('click', function(e) {
+        var textToWrite = '\ufeff' + $(this).parent().prev('pre').text().replace(/\n/g, "\r\n");
+        var textFileAsBlob = new Blob([textToWrite], {type:'text/csv'});
+        var fileNameToSaveAs = location.pathname.match(/([^\/]+)(?=\.\w+$)/)[0] + "-Script.ahk";
+
+        var downloadLink = document.createElement("a");
+        downloadLink.download = fileNameToSaveAs;
+        downloadLink.innerHTML = "Download File";
+
+        if (window.webkitURL != null) {
+          // Chrome
+          downloadLink.href = window.webkitURL.createObjectURL(textFileAsBlob);
+          downloadLink.click();
+        }
+        else if (navigator.userAgent.indexOf("Trident")>-1) {
+          // IE 10+
+          navigator.msSaveBlob(textFileAsBlob, fileNameToSaveAs)
+        }
+        else {
+          // Firefox
+          downloadLink.href = window.URL.createObjectURL(textFileAsBlob);
+          downloadLink.style.display = "none";
+          document.body.appendChild(downloadLink);
+          downloadLink.click();
+        }
+      });
+    });
+
+    //
     // language button
     //
 


### PR DESCRIPTION
This shows the buttons select and download in lower right corner of a pre box.

Select button will select the complete code so that the user can copy it into the clipboard. Tested with Chrome, Firefox and IE8+.

Download button will download the complete code into a file with the format "[url file name]-Script.ahk"; including a BOM. Works only in HTML5-able browsers (because of the added download attribute) and IE10+.