### PR TITLE
Update Search function - #ref bugfix

### DIFF
--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -80,14 +80,14 @@ function AddContent()
     //
 
     $('.header #search-btn').on('click', function() {
-      var query = $(".header #q").val();
+      var query = encodeURIComponent( $(".header #q").val() );
       document.location = eval(sessionStorage.getItem("hdSearchLnk"));
     });
 
     $('.header #search-form').on('submit', function(event) {
-        event.preventDefault();
-        var query = $(".header #q").val();
-        document.location = eval(sessionStorage.getItem("hdSearchLnk"));
+      event.preventDefault();
+      var query = encodeURIComponent( $(".header #q").val() );
+      document.location = eval(sessionStorage.getItem("hdSearchLnk"));
     });
 
     //


### PR DESCRIPTION
The query needs to be encoded. For example: `#if winactive` needs to be `%23if%20winactive` or `%23if+winactive`, otherwise the search page will handle it as a ref `#`. `encodeURIComponent()` fixes this.
see **jsfiddle:** http://jsfiddle.net/joedf/x5khrsjm/
