### PR TITLE
Force reading files as UTF-8

### DIFF
--- a/docs/static/source/CreateFiles4Help.ahk
+++ b/docs/static/source/CreateFiles4Help.ahk
@@ -9,6 +9,7 @@ FileList := { MainJS:       "main.js"
             , JQueryJS:     "jquery.js"
             , TreeJQueryJS: "tree.jquery.js" }
 
+FileEncoding, UTF-8
 For var, file in FileList
 	FileRead %var%, %A_ScriptDir%\%file%
 


### PR DESCRIPTION
... to prevent showing non-english characters as gibberish inside the navbar of chm or online help.