### PR TITLE
Adding prefix "My" to examples

### DIFF
--- a/docs/Objects.htm
+++ b/docs/Objects.htm
@@ -48,74 +48,74 @@ ul.list_of_p li { margin: 1em 0; }
 
 <h3 id="Usage_Simple_Arrays">Simple Arrays</h3>
 <p>Create an array:</p>
-<pre>Array := [Item1, Item2, ..., ItemN]
-Array := Array(Item1, Item2, ..., ItemN)</pre>
+<pre>MyArray := [Item1, Item2, ..., ItemN]
+MyArray := Array(Item1, Item2, ..., ItemN)</pre>
 <p>Retrieve an item:</p>
-<pre>Value := Array[Index]</pre>
+<pre>Value := MyArray[Index]</pre>
 <p>Assign an item:</p>
-<pre>Array[Index] := Value</pre>
+<pre>MyArray[Index] := Value</pre>
 <p>Insert one or more items at a given index:</p>
-<pre>Array.<a href="objects/Object.htm#InsertAt">InsertAt</a>(Index, Value, Value2, ...)</pre>
+<pre>MyArray.<a href="objects/Object.htm#InsertAt">InsertAt</a>(Index, Value, Value2, ...)</pre>
 <p>Append one or more items:</p>
-<pre>Array.<a href="objects/Object.htm#Push">Push</a>(Value, Value2, ...)</pre>
+<pre>MyArray.<a href="objects/Object.htm#Push">Push</a>(Value, Value2, ...)</pre>
 <p>Remove an item:</p>
-<pre>RemovedValue := Array.<a href="objects/Object.htm#RemoveAt">RemoveAt</a>(Index)</pre>
+<pre>RemovedValue := MyArray.<a href="objects/Object.htm#RemoveAt">RemoveAt</a>(Index)</pre>
 <p>Remove the last item:</p>
-<pre>RemovedValue := Array.<a href="objects/Object.htm#Pop">Pop</a>()</pre>
+<pre>RemovedValue := MyArray.<a href="objects/Object.htm#Pop">Pop</a>()</pre>
 <p>If the array is not empty, <a href="objects/Object.htm#MinMaxIndex">MinIndex</a> and <a href="objects/Object.htm#MinMaxIndex">MaxIndex</a>/<a href="objects/Object.htm#Length">Length</a> return the lowest and highest index currently in use in the array. Since the lowest index is nearly always 1, MaxIndex usually returns the number of items. However, if there are no integer keys, MaxIndex returns an empty string whereas Length returns 0. Looping through an array's contents can be done either by index or with a For-loop. For example:</p>
-<pre>array := ["one", "two", "three"]
+<pre>MyArray := ["one", "two", "three"]
 
 <em>; Iterate from 1 to the end of the array:</em>
-<a href="commands/Loop.htm">Loop</a> % array.Length()
-    MsgBox % array[A_Index]
+<a href="commands/Loop.htm">Loop</a> % MyArray.Length()
+    MsgBox % MyArray[A_Index]
 
 <em>; Enumerate the array's contents:</em>
-<a href="commands/For.htm">For</a> index, value in array
-    MsgBox % "Item " index " is '" value "'"
+<a href="commands/For.htm">For</a> Index, Value in MyArray
+    MsgBox % "Item " Index " is '" Value "'"
 </pre>
 
 <a name="Arrays"></a><h3 id="Usage_Associative_Arrays">Associative Arrays</h3>
 <p>An associative array is an object which contains a collection of unique keys and a collection of values, where each key is associated with one value. Keys can be strings, integers or objects, while values can be of any type. An associative array can be created as follows:</p>
-<pre>Array := {KeyA: ValueA, KeyB: ValueB, ..., KeyZ: ValueZ}
-Array := Object("KeyA", ValueA, "KeyB", ValueB, ..., "KeyZ", ValueZ)</pre>
-<p>Using the <code>{key:value}</code> notation, quote marks are optional for keys which consist only of word characters. Any expression can be used as a key, but to use a variable as a key, it must be enclosed in parentheses. For example, <code>{(KeyVar): Value}</code> and <code>{GetKey(): Value}</code> are both valid.</p>
+<pre>MyArray := {KeyA: ValueA, KeyB: ValueB, ..., KeyZ: ValueZ}
+MyArray := Object("KeyA", ValueA, "KeyB", ValueB, ..., "KeyZ", ValueZ)</pre>
+<p>Using the <code>{Key:Value}</code> notation, quote marks are optional for keys which consist only of word characters. Any expression can be used as a key, but to use a variable as a key, it must be enclosed in parentheses. For example, <code>{(KeyVar): Value}</code> and <code>{GetKey(): Value}</code> are both valid.</p>
 <p>Retrieve an item:</p>
-<pre>Value := Array[Key]</pre>
+<pre>Value := MyArray[Key]</pre>
 <p>Assign an item:</p>
-<pre>Array[Key] := Value</pre>
+<pre>MyArray[Key] := Value</pre>
 <p>Remove an item:</p>
-<pre>RemovedValue := Array.<a href="objects/Object.htm#Delete">Delete</a>(Key)</pre>
+<pre>RemovedValue := MyArray.<a href="objects/Object.htm#Delete">Delete</a>(Key)</pre>
 <p>Enumerating items:</p>
-<pre>array := {ten: 10, twenty: 20, thirty: 30}
-<a href="commands/For.htm">For</a> key, value in array
-    MsgBox %key% = %value%</pre>
+<pre>MyArray := {ten: 10, twenty: 20, thirty: 30}
+<a href="commands/For.htm">For</a> Key, Value in MyArray
+    MsgBox %Key% = %Value%</pre>
 <p>Associative arrays can be sparsely populated - that is, <code>{1:"a",1000:"b"}</code> contains only two key-value pairs, not 1000.</p>
 <p id="same_thing">In AutoHotkey v1.x, simple arrays and associative arrays are the same thing. However, treating <code>[]</code> as a simple linear array helps to keep its role clear, and improves the chance of your script working with a future version of AutoHotkey, which might differentiate between simple arrays and associative arrays.</p>
 
 <h3 id="Usage_Objects">Objects</h3>
 <p>Retrieve a property:</p>
-<pre>Value := Object.Property</pre>
+<pre>Value := MyObject.Property</pre>
 <p>Set a property:</p>
-<pre>Object.Property := Value</pre>
+<pre>MyObject.Property := Value</pre>
 <p>Call a method:</p>
-<pre>ReturnValue := Object.Method(Parameters)</pre>
+<pre>ReturnValue := MyObject.Method(Params)</pre>
 <p>Call a method with a computed method name:</p>
-<pre>ReturnValue := Object[MethodName](Parameters)</pre>
+<pre>ReturnValue := MyObject[VarContainingMethodName](Params)</pre>
 <p>Some properties of COM objects and user-defined objects can accept parameters:</p>
-<pre>Value := Object.Property[Parameters]
-Object.Property[Parameters] := Value</pre>
+<pre>Value := MyObject.Property[Params]
+MyObject.Property[Params] := Value</pre>
 <p><strong>Related:</strong> <a href="objects/Object.htm">Object</a>, <a href="objects/File.htm">File Object</a>, <a href="objects/Func.htm">Func Object</a>, <a href="commands/ComObjCreate.htm">COM object</a></p>
 <p><b>Known limitation:</b></p>
 <ul><li>Currently <code><span class="dull">x</span>.y[z]<span class="dull">()</span></code> is treated as <code><span class="dull">x</span>["y", z]<span class="dull">()</span></code>, which is not supported. As a workaround, <code><span class="red">(</span><span class="dull">x.y</span><span class="red">)</span>[z]()</code> evaluates <code>x.y</code> first, then uses the result as the target of the method call. Note that <code>x.y[z].Call()</code> does not have this limitation since it is evaluated the same as <code>(x.y[z]).Call()</code>.</li></ul>
 
 <h3 id="Usage_Freeing_Objects">Freeing Objects</h3>
 <p>Scripts do not free objects explicitly. When the last reference to an object is released, the object is freed automatically. A reference stored in a variable is released automatically when that variable is assigned some other value. For example:</p>
-<pre>obj := {}  <em>; Creates an object.</em>
-obj := ""  <em>; Releases the last reference, and therefore frees the object.</em></pre>
+<pre>MyObject := {}  <em>; Creates an object.</em>
+MyObject := ""  <em>; Releases the last reference, and therefore frees the object.</em></pre>
 <p>Similarly, a reference stored in a field of another object is released when that field is assigned some other value or removed from the object. This also applies to arrays, which are actually objects.</p>
-<pre>arr := [{}]  <em>; Creates an array containing an object.</em>
-arr[1] := {}  <em>; Creates a second object, implicitly freeing the first object.</em>
-arr.Remove(1)  <em>; Removes and frees the second object.</em></pre>
+<pre>MyArray := [{}]    <em>; Creates an array containing an object.</em>
+MyArray[1] := {}   <em>; Creates a second object, implicitly freeing the first object.</em>
+MyArray.Remove(1)  <em>; Removes and frees the second object.</em></pre>
 <p id="Circular_References">Because all references to an object must be released before the object can be freed, objects containing circular references aren't freed automatically. For instance, if <code>x.child</code> refers to <code>y</code> and <code>y.parent</code> refers to <code>x</code>, clearing <code>x</code> and <code>y</code> is not sufficient since the parent object still contains a reference to the child and vice versa. To resolve this situation, remove the circular reference.</p>
 <pre>
 x := {}, y := {}             <em>; Create two objects.</em>
@@ -133,14 +133,14 @@ x := "", y := ""             <em>; Without the above line, this would not free t
 <p>Additionally, object references can themselves be used in expressions:</p>
 <ul>
   <li>When an object reference is compared with some other value using one of <code>= == != &lt;&gt;</code>, they are considered equal only if both values are references to the same object.</li>
-  <li>Objects are always considered <i>true</i> when a boolean value is required, such as in <code>if obj</code>, <code>!obj</code> or <code>obj ? x : y</code>.</li>
+  <li>Objects are always considered <i>true</i> when a boolean value is required, such as in <code>if MyObject</code>, <code>!MyObject</code> or <code>MyObject ? x : y</code>.</li>
   <li>An object's address can be retrieved using the <code>&amp;</code>address-of operator. This uniquely identifies the object from the point of its creation to the moment its last reference is <a href="#Refs">released</a>.</li>
 </ul>
-<p>If an object is used in any context where an object is not expected, it is treated as an empty string. For example, <code>MsgBox %object%</code> shows an empty MsgBox and <code>object + 1</code> yields an empty string. Do not rely on this behaviour as it may change.</p>
+<p>If an object is used in any context where an object is not expected, it is treated as an empty string. For example, <code>MsgBox %MyObject%</code> shows an empty MsgBox and <code>MyObject + 1</code> yields an empty string. Do not rely on this behaviour as it may change.</p>
 <p>When a method-call is followed immediately by an assignment operator, it is equivalent to setting a property with parameters. For example, the following are equivalent:</p>
-<pre>obj.item(x) := y
-obj.item[x] := y</pre>
-<p id="cassign">Compound assignments such as <code>x.y += 1</code> and <code>--arr[1]</code> are supported.</p>
+<pre>MyObject.Item(x) := y
+MyObject.Item[x] := y</pre>
+<p id="cassign">Compound assignments such as <code>x.y += 1</code> and <code>--MyArray[1]</code> are supported.</p>
 <p><span class="ver">[v1.1.20+]:</span> Parameters can be omitted when getting or setting properties. For example, <code>x[,2]</code>. Scripts can utilize this by defining default values for parameters in <a href="#Custom_Classes_property">properties</a> and <a href="#Meta_Functions">meta-functions</a>. The method name can also be completely omitted, as in <code>x[](a)</code>. Scripts can utilize this by defining a default value for the __Call <a href="#Meta_Functions">meta-function</a>'s first parameter, since it is not otherise supplied with a value. Note that this differs from <code>x.(a)</code>, which is equivalent to <code>x[""](a)</code>. If the property or method name is omitted when invoking a COM object, its "default member" is invoked.</p>
 
 <h4>Keys</h4>
@@ -155,13 +155,13 @@ obj.item[x] := y</pre>
 
 <h2 id="Extended_Usage">Extended Usage</h2>
 <h3 id="Function_References">Function References <span class="ver">[v1.1.00+]</span></h3>
-<p>If the variable <i>func</i> contains a function name, the function can be called one of two ways: <code>%func%()</code> or <code>func.()</code>. However, this requires the function name to be resolved each time, which is inefficient if the function is called more than once. To improve performance, the script can retrieve a reference to the function and store it for later use:</p>
-<pre>Func := Func("MyFunc")</pre>
+<p>If the variable <i>MyFunc</i> contains a function name, the function can be called one of two ways: <code>%MyFunc%()</code> or <code>MyFunc.()</code>. However, this requires the function name to be resolved each time, which is inefficient if the function is called more than once. To improve performance, the script can retrieve a reference to the function and store it for later use:</p>
+<pre>FuncRef := Func("MyFuncName")</pre>
 <p>A function can be called by reference using the following syntax:</p>
 <pre>
-RetVal := %Func%(<i>Params</i>)     <em>; Requires v1.1.07+</em>
-RetVal := Func.Call(<i>Params</i>)  <em>; Requires v1.1.19+</em>
-RetVal := Func.(<i>Params</i>)      <em>; Not recommended</em>
+ReturnValue := %FuncRef%(<i>Params</i>)     <em>; Requires v1.1.07+</em>
+ReturnValue := FuncRef.Call(<i>Params</i>)  <em>; Requires v1.1.19+</em>
+ReturnValue := FuncRef.(<i>Params</i>)      <em>; Not recommended</em>
 </pre>
 <p>For details about additional properties of function references, see <a href="objects/Func.htm">Func Object</a>.</p>
 
@@ -189,59 +189,59 @@ table.base.__Set(table, x, y, content)     <em>; B</em></pre>
 
 <h3 id="Usage_Arrays_of_Functions"><a name="FuncArrays"></a>Arrays of Functions</h3>
 <p>An array of functions is simply an array containing function names or references. For example:</p>
-<pre>array := [Func("FirstFunc"), Func("SecondFunc")]
+<pre>MyArray := [Func("FirstFunc"), Func("SecondFunc")]
 
 <em>; Call each function, passing "foo" as a parameter:</em>
 Loop 2
-    array[A_Index].("foo")
+    MyArray[A_Index].("foo")
 
 <em>; Call each function, implicitly passing the array itself as a parameter:</em>
 Loop 2
-    array[A_Index]()
+    MyArray[A_Index]()
 
-FirstFunc(param) {
-    MsgBox % A_ThisFunc ": " (IsObject(param) ? "object" : param)
+FirstFunc(Param) {
+    MsgBox % A_ThisFunc ": " (IsObject(Param) ? "object" : Param)
 }
-SecondFunc(param) {
-    MsgBox % A_ThisFunc ": " (IsObject(param) ? "object" : param)
+SecondFunc(Param) {
+    MsgBox % A_ThisFunc ": " (IsObject(Param) ? "object" : Param)
 }</pre>
-<p>For backward-compatibility, the second form will not pass <i>array</i> as a parameter if <code>array[A_Index]</code> contains a function name instead of a function reference. However, if <code>array[A_Index]</code> is <a href="#Custom_Objects">inherited</a> from <code>array.base[A_Index]</code>, <i>array</i> will be passed as a parameter.</p>
+<p>For backward-compatibility, the second form will not pass <i>MyArray</i> as a parameter if <code>MyArray[A_Index]</code> contains a function name instead of a function reference. However, if <code>MyArray[A_Index]</code> is <a href="#Custom_Objects">inherited</a> from <code>MyArray.base[A_Index]</code>, <i>MyArray</i> will be passed as a parameter.</p>
 
 <h2 id="Custom_Objects">Custom Objects</h2>
 <p>Objects created by the script do not need to have any predefined structure. Instead, each object can inherit properties and methods from its <code>base</code> object (otherwise known as a "prototype" or "class"). Properties and methods can also be added to (or removed from) an object at any time, and those changes will affect any and all derived objects. For more complex or specialized situations, a base object can override the standard behaviour of any objects derived from it by defining <a href="#Meta_Functions"><i>meta-functions</i></a>.</p>
 <p><em>Base</em> objects are just ordinary objects, and are typically created one of two ways:</p>
-<pre>class baseObject {
+<pre>class MyObject {
     static foo := "bar"
 }
 <em>; OR</em>
-baseObject := {foo: "bar"}</pre>
+MyObject := {foo: "bar"}</pre>
 <p>To create an object derived from another object, scripts can assign to the <code>base</code> property or use the <a href="#Custom_NewDelete"><code>new</code> keyword</a>:</p>
-<pre>obj1 := Object(), obj1.base := baseObject
-obj2 := {base: baseObject}
-obj3 := new baseObject
-MsgBox % obj1.foo " " obj2.foo " " obj3.foo</pre>
+<pre>Object1 := Object(), Object1.base := MyObject
+Object2 := {base: MyObject}
+Object3 := new MyObject
+MsgBox % Object1.foo " " Object2.foo " " Object3.foo</pre>
 <p>It is possible to reassign an object's <code>base</code> at any time, effectively replacing all of the properties and methods that the object inherits.</p>
 
 <h3 id="Custom_Prototypes">Prototypes</h3>
 <p>Prototype or <code>base</code> objects are constructed and manipulated the same as any other object. For example, an ordinary object with one property and one method might be constructed like this:</p>
 <pre><em>; Create an object.</em>
-thing := {}
+MyObject := {}
 <em>; Store a value.</em>
-thing.foo := "bar"
+MyObject.foo := "bar"
 <em>; Create a method by storing a function reference.</em>
-thing.test := Func("thing_test")
+MyObject.Method := Func("MyObject_Method")
 <em>; Call the method.</em>
-thing.test()
+MyObject.Method()
 
-thing_test(this) {
+MyObject_Method(this) {
    MsgBox % this.foo
 }</pre>
-<p>When <code>thing.test()</code> is called, <i>thing</i> is automatically inserted at the beginning of the parameter list. However, for backward-compatibility, this does not occur when a function is stored by name (rather than by reference) directly in the object (rather than being inherited from a base object). By convention, the function is named by combining the "type" of object and the method name.</p>
+<p>When <code>MyObject.Method()</code> is called, <i>MyObject</i> is automatically inserted at the beginning of the parameter list. However, for backward-compatibility, this does not occur when a function is stored by name (rather than by reference) directly in the object (rather than being inherited from a base object). By convention, the function is named by combining the "type" of object and the method name.</p>
 <p>An object is a <i>prototype</i> or <i>base</i> if another object derives from it:</p>
-<pre>other := {}
-other.base := thing
-other.test()</pre>
-<p>In this case, <i>other</i> inherits <i>foo</i> and <i>test</i> from <i>thing</i>. This inheritance is dynamic, so if <code>thing.foo</code> is modified, the change will be reflected by <code>other.foo</code>. If the script assigns to <code>other.foo</code>, the value is stored in <i>other</i> and any further changes to <code>thing.foo</code> will have no effect on <code>other.foo</code>. When <code>other.test()</code> is called, its <i>this</i> parameter contains a reference to <i>other</i> instead of <i>thing</i>.
+<pre>OtherObject := {}
+OtherObject.base := MyObject
+OtherObject.Method()</pre>
+<p>In this case, <i>OtherObject</i> inherits <i>foo</i> and <i>Method</i> from <i>MyObject</i>. This inheritance is dynamic, so if <code>MyObject.foo</code> is modified, the change will be reflected by <code>OtherObject.foo</code>. If the script assigns to <code>OtherObject.foo</code>, the value is stored in <i>OtherObject</i> and any further changes to <code>MyObject.foo</code> will have no effect on <code>OtherObject.foo</code>. When <code>OtherObject.Method()</code> is called, its <i>this</i> parameter contains a reference to <i>OtherObject</i> instead of <i>MyObject</i>.
 </p>
 
 <h3 id="Custom_Classes">Classes <span class="ver">[v1.1.00+]</span></h3>
@@ -267,12 +267,12 @@ other.test()</pre>
             return ...
         }
         set {
-            return ... := value
+            return ... := Value
         }
     }
 }
 </pre>
-<p>When the script is loaded, this constructs an object and stores it in the global (or in v1.1.05+, <a href="Functions.htm#SuperGlobal">super-global</a>) variable <i>ClassName</i>. Prior to v1.1.05, to reference this class inside a function, a declaration such as <code>global ClassName</code> is required unless the function is <a href="Functions.htm#AssumeGlobal">assume-global</a>. If <code>extends BaseClassName</code> is present, <i>BaseClassName</i> must be the full name of another class (but as of v1.1.11, the order that they are defined in does not matter). The full name of each class is stored in <code><i>object</i>.__Class</code>.</p>
+<p>When the script is loaded, this constructs an object and stores it in the global (or in v1.1.05+, <a href="Functions.htm#SuperGlobal">super-global</a>) variable <i>ClassName</i>. Prior to v1.1.05, to reference this class inside a function, a declaration such as <code>global ClassName</code> is required unless the function is <a href="Functions.htm#AssumeGlobal">assume-global</a>. If <code>extends BaseClassName</code> is present, <i>BaseClassName</i> must be the full name of another class (but as of v1.1.11, the order that they are defined in does not matter). The full name of each class is stored in <code><i>MyObject</i>.__Class</code>.</p>
 <p>Within this documentation, the word "class" on its own usually means a class object constructed with the <code>class</code> keyword.</p>
 <p>Class definitions can contain variable declarations, method definitions and nested class definitions.</p>
 
@@ -313,7 +313,7 @@ Method()
   <li><code>base.Method()</code> always invokes the base of the class where the current method was defined, even if <code>this</code> is derived from a <em>sub-class</em> of that class or some other class entirely.</li>
   <li><code>base.Method()</code> implicitly passes <code>this</code> as the first (hidden) parameter.</li>
 </ul>
-<p><code>base</code> only has special meaning if followed by a dot <code>.</code> or brackets <code>[]</code>, so code like <code>obj := base, obj.Method()</code> will not work. Scripts can disable the special behaviour of <i>base</i> by assigning it a non-empty value; however, this is not recommended. Since the variable <i>base</i> must be empty, performance may be reduced if the script omits <a href="commands/_NoEnv.htm">#NoEnv</a>.</p>
+<p><code>base</code> only has special meaning if followed by a dot <code>.</code> or brackets <code>[]</code>, so code like <code>MyObject := base, MyObject.Method()</code> will not work. Scripts can disable the special behaviour of <i>base</i> by assigning it a non-empty value; however, this is not recommended. Since the variable <i>base</i> must be empty, performance may be reduced if the script omits <a href="commands/_NoEnv.htm">#NoEnv</a>.</p>
 
 <h4 id="Custom_Classes_property">Properties <span class="ver">[v1.1.16+]</span></h4>
 <p>Property definitions allow a method to be executed whenever the script gets or sets a specific key.</p>
@@ -323,12 +323,12 @@ Method()
         return ...
     }
     set {
-        return ... := value
+        return ... := Value
     }
 }</pre>
-<p><em>Property</em> is simply the name of the property, which will be used to invoke it. For example, <code>obj.Property</code> would call <em>get</em> while <code>obj.Property := value</code> would call <em>set</em>. Within <em>get</em> or <em>set</em>, <code>this</code> refers to the object being invoked. Within <em>set</em>, <code>value</code> contains the value being assigned.</p>
+<p><em>Property</em> is simply the name of the property, which will be used to invoke it. For example, <code>MyObject.Property</code> would call <em>get</em> while <code>MyObject.Property := Value</code> would call <em>set</em>. Within <em>get</em> or <em>set</em>, <code>this</code> refers to the object being invoked. Within <em>set</em>, <code>Value</code> contains the value being assigned.</p>
 <p>Parameters can be passed by enclosing them in square brackets to the right of the property name, both when defining the property and when calling it. Aside from using square brackets, parameters of properties are defined the same way as parameters of methods - optional, ByRef and variadic parameters are supported.</p>
-<p>The return value of <em>get</em> or <em>set</em> becomes the result of the sub-expression which invoked the property. For example, <code>val := obj.Property := 42</code> stores the return value of <em>set</em> in <code>val</code>.</p>
+<p>The return value of <em>get</em> or <em>set</em> becomes the result of the sub-expression which invoked the property. For example, <code>Value := MyObject.Property := 42</code> stores the return value of <em>set</em> in <code>Value</code>.</p>
 <p>Each class can define one or both halves of a property. If a class overrides a property, it can use <code><a href="#Custom_Classes_base">base.Property</a></code> to access the property defined by its base class. If <em>get</em> or <em>set</em> is not defined, it can be handled by a base class. If <em>set</em> is not defined and is not handled by a meta-function or base class, assigning a value stores it in the object, effectively disabling the property.</p>
 <p>Internally, <em>get</em> and <em>set</em> are two separate methods, so cannot share variables (except by storing them in <code>this</code>).</p>
 <p><a href="#Meta_Functions">Meta-functions</a> provide a broader way of controlling access to properties and methods of an object, but are more complicated and error-prone.</p>
@@ -373,7 +373,7 @@ class <i>ClassName</i> {
 
 <i>ClassName</i> := { __Get: Func("<i>MyGet</i>"), __Set: Func("<i>MySet</i>"), __Call: Func("<i>MyCall</i>") }
 </pre>
-<p>Meta-functions define what happens when a key is requested but not found within the target object. For example, if <code>obj.key</code> has not been assigned a value, it invokes the <i>__Get</i> meta-function. Similarly, <code>obj.key := value</code> invokes <i>__Set</i> and <code>obj.key()</code> invokes <i>__Call</i>. These meta-functions (or methods) would need to be defined in <code>obj.base</code>, <code>obj.base.base</code> or such.</p>
+<p>Meta-functions define what happens when a key is requested but not found within the target object. For example, if <code>MyObject.Key</code> has not been assigned a value, it invokes the <i>__Get</i> meta-function. Similarly, <code>MyObject.Key := Value</code> invokes <i>__Set</i> and <code>MyObject.Key()</code> invokes <i>__Call</i>. These meta-functions (or methods) would need to be defined in <code>MyObject.base</code>, <code>MyObject.base.base</code> or such.</p>
 <p>When the script gets, sets or calls a key which does not exist within the target object, the base object is invoked as follows:</p>
 <ul class="list_of_p">
   <li>If this base object defines the appropriate meta-function, call it.  If the meta-function explicitly <code>return</code>s, use the return value as the result of the operation (whatever caused the meta-function to be called) and return control to the script. Otherwise, continue as described below.
@@ -450,28 +450,28 @@ class Color
 }</pre>
 
 <h4 id="Objects_as_Functions">Objects as Functions</h4>
-<p>When a call such as <code>obj.func(param)</code> is made, <i>obj.func</i> may contain a function name or an object.  If <i>obj.func</i> contains an object, that object is invoked with <i>obj</i> in place of the method name, as in <code>(obj.func)[obj]()</code>.  In most cases <code>obj.func[obj]</code> does not exist and <i>obj.func</i>'s __Call <a href="#Meta_Functions">meta-function</a> is invoked instead.  This may be used to change the behaviour of function calls in an abstract way, as shown in the example below:</p>
+<p>When a call such as <code>MyObject.Function(Param)</code> is made, <i>MyObject.Function</i> may contain a function name or an object. If <i>MyObject.Function</i> contains an object, that object is invoked with <i>MyObject</i> in place of the method name, as in <code>(MyObject.Function)[MyObject]()</code>. In most cases <code>MyObject.Function[MyObject]</code> does not exist and <i>MyObject.Function</i>'s __Call <a href="#Meta_Functions">meta-function</a> is invoked instead. This may be used to change the behaviour of function calls in an abstract way, as shown in the example below:</p>
 <pre><em>; Create a prototype for an array of functions.</em>
 FuncArrayType := {__Call: "FuncType_Call"}
 <em>; Create an array of functions.</em>
-funcArray := {1: "One", 2: "Two", base: FuncArrayType}
+FuncArray := {1: "One", 2: "Two", base: FuncArrayType}
 <em>; Create an object which uses the array as a method.</em>
-obj := {func: funcArray}
+MyObject := {Function: FuncArray}
 <em>; Call the method.</em>
-obj.func("foo", "bar")
+MyObject.Function("foo", "bar")
 
-FuncType_Call(func, obj, params*)
+FuncType_Call(aFunc, aObj, aParams*)
 {
     <em>; Call a list of functions.</em>
-    Loop % ObjMaxIndex(func)
-        func[A_Index](params*)
+    Loop % ObjMaxIndex(aFunc)
+        aFunc[A_Index](aParams*)
 }
 
-One(param1, param2) {
+One(Param1, Param2) {
     ListVars
     Pause
 }
-Two(param1, param2) {
+Two(Param1, Param2) {
     ListVars
     Pause
 }</pre>
@@ -555,10 +555,10 @@ x_Addr(x) {
 empty_var.foo := "bar"
 MsgBox % empty_var.foo
 
-Default_Set_AutomaticVarInit(ByRef var, key, value)
+Default_Set_AutomaticVarInit(ByRef Var, Key, Value)
 {
-    if (var = "")
-        var := Object(key, value)
+    if (Var = "")
+        Var := Object(Key, Value)
 }</pre>
 
 <h4 id="Pseudo_Properties">Pseudo-Properties</h4>
@@ -566,24 +566,24 @@ Default_Set_AutomaticVarInit(ByRef var, key, value)
 <pre>"".base.__Get := Func("Default_Get_PseudoProperty")
 "".base.is    := Func("Default_is")
 
-MsgBox % A_AhkPath.length " == " StrLen(A_AhkPath)
-MsgBox % A_AhkPath.length.is("integer")
+MsgBox % A_AhkPath.StringLength " == " StrLen(A_AhkPath)
+MsgBox % A_AhkPath.StringLength.is("integer")
 
-Default_Get_PseudoProperty(nonobj, key)
+Default_Get_PseudoProperty(NonObject, Key)
 {
-    if (key = "length")
-        return StrLen(nonobj)
+    if (Key = "StringLength")
+        return StrLen(NonObject)
 }
 
-Default_is(nonobj, type)
+Default_is(NonObject, Type)
 {
-    if nonobj is %type%
+    if NonObject is %Type%
         return true
     return false
 }</pre>
 <p>Note that built-in functions may also be used, but in this case the parentheses cannot be omitted:</p>
-<pre>"".base.length := Func("StrLen")
-MsgBox % A_AhkPath.length() " == " StrLen(A_AhkPath)</pre>
+<pre>"".base.StringLength := Func("StrLen")
+MsgBox % A_AhkPath.StringLength() " == " StrLen(A_AhkPath)</pre>
 
 <h4 id="Default__Warn">Debugging</h4>
 <p>If allowing a value to be treated as an object is undesirable, a warning may be shown whenever a non-object value is invoked:</p>
@@ -592,23 +592,23 @@ MsgBox % A_AhkPath.length() " == " StrLen(A_AhkPath)</pre>
 empty_var.foo := "bar"
 x := (1 + 1).is("integer")
 
-Default__Warn(nonobj, p1="", p2="", p3="", p4="")
+Default__Warn(NonObject, P1="", P2="", P3="", P4="")
 {
     ListLines
-    MsgBox A non-object value was improperly invoked.`n`nSpecifically: %nonobj%
+    MsgBox A non-object value was improperly invoked.`n`nSpecifically: %NonObject%
 }</pre>
 
 <h2 id="Implementation">Implementation</h2>
 <a name="Refs"></a><h3 id="Reference_Counting">Reference-Counting</h3>
 <p>AutoHotkey uses a basic reference-counting mechanism to automatically free the resources used by an object when it is no longer referenced by the script.  Script authors should not invoke this mechanism explicitly, except when dealing directly with unmanaged pointers to objects. For more information, see <a href="commands/ObjAddRef.htm">ObjAddRef</a>.</p>
 <pre><em>; Increment the object's reference count to "keep it alive":</em>
-<a href="commands/ObjAddRef.htm">ObjAddRef</a>(address)
+<a href="commands/ObjAddRef.htm">ObjAddRef</a>(Address)
 ...
 <em>; Decrement the object's reference count to allow it to be freed:</em>
-ObjRelease(address)
+ObjRelease(Address)
 </pre>
-<p>However, ObjAddRef does not need to be used when initially obtaining an address via <code><a href="#AddressCast">Object(obj)</a></code>.</p>
-<p>Generally each new copy of an object's address should be treated as an object reference, except that the script is responsible for calling ObjAddRef and/or ObjRelease as appropriate. For example, whenever an address is copied via something like <code>x := address</code>, ObjAddRef should be called to increment the reference count. Similarly, whenever the script is finished with a particular copy of the object's address, it should call ObjRelease. This ensures the object is freed when the last reference to it is lost - and not before then.</p>
+<p>However, ObjAddRef does not need to be used when initially obtaining an address via <code><a href="#AddressCast">Object(MyObject)</a></code>.</p>
+<p>Generally each new copy of an object's address should be treated as an object reference, except that the script is responsible for calling ObjAddRef and/or ObjRelease as appropriate. For example, whenever an address is copied via something like <code>x := Address</code>, ObjAddRef should be called to increment the reference count. Similarly, whenever the script is finished with a particular copy of the object's address, it should call ObjRelease. This ensures the object is freed when the last reference to it is lost - and not before then.</p>
 <p>To run code when the last reference to an object is being released, implement the <a href="#Custom_NewDelete">__Delete</a> meta-function.</p>
 <p><b>Known Limitations:</b></p>
 <ul>
@@ -618,10 +618,10 @@ ObjRelease(address)
 <p>Although memory used by the object is reclaimed by the operating system when the program exits, <a href="#Custom_NewDelete">__Delete</a> will not be called unless all references to the object are freed.  This can be important if it frees other resources which are not automatically reclaimed by the operating system, such as temporary files.</p>
 
 <a name="AddressCast"></a><h3 id="Implementation_Pointers">Pointers to Objects</h3>
-<p>In some rare cases it may be necessary to pass an object to external code via DllCall or store it in a binary data structure for later retrieval. An object's address can be retrieved by <code>x := &amp;obj</code>; however, if the variable <i>obj</i> is cleared, the object may be freed prematurely. To ensure this does not occur, use ObjAddRef as shown above or the <code>Object()</code> function as shown below:</p>
-<pre>address := Object(object)</pre>
+<p>In some rare cases it may be necessary to pass an object to external code via DllCall or store it in a binary data structure for later retrieval. An object's address can be retrieved by <code>x := &amp;MyObject</code>; however, if the variable <i>MyObject</i> is cleared, the object may be freed prematurely. To ensure this does not occur, use ObjAddRef as shown above or the <code>Object()</code> function as shown below:</p>
+<pre>Address := Object(MyObject)</pre>
 <p>Additionally, this function can also be used to convert the address back into a reference:</p>
-<pre>object := Object(address)</pre>
+<pre>MyObject := Object(Address)</pre>
 <p>In either case the object's <a href="#Refs">reference-count</a> is automatically incremented so that the object is not freed prematurely.</p>
 <p>Note that this function applies equally to objects not created by <a href="#Arrays">Object()</a>, such as <a href="commands/ComObjCreate.htm">COM object wrappers</a> or <a href="objects/File.htm">File objects</a>.</p>
 


### PR DESCRIPTION
Make Differentiation more obvious between using a word literally or as an example by adding prefix "My".