### PR TITLE
Changed german docs link

### DIFF
--- a/docs/static/source/main.js
+++ b/docs/static/source/main.js
@@ -119,7 +119,7 @@ function AddContent()
     //
 
     var en = 'http://ahkscript.org/docs/';
-    var de = 'http://ragnar-f.github.io/docs/';
+    var de = 'http://ahkde.github.io/docs/';
     var cn = 'http://ahkcn.sourceforge.net/docs/';
 
     $('#lng-btn-en').on('click', function() { document.location = en + relPath; } );


### PR DESCRIPTION
Also, could you please change the links on autohotkey.com:

**/index.htm**:

`http://ragnar-f.github.com/docs` -> `https://ahkde.github.io/docs`
`https://github.com/Ragnar-F/ragnar-f.github.com` -> `https://github.com/ahkde/docs`

**/download/index.htm**:

`https://github.com/Ragnar-F/ahk_docs_german/releases/latest` -> `https://github.com/ahkde/docs/releases/latest`

Thanks in advance.