### PR TITLE
broken StrSplit() link

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -310,7 +310,7 @@ path-to-the-currently-running-AutoHotkey.exe\Lib\  <em>; Standard library.</em><
     <td>Retrieves the count of how many characters are in a string.</td>
   </tr>
   <tr id="StrSplit">
-    <td><a href="commands/StringSplit.htm">StrSplit</a></td>
+    <td><a href="commands/StrSplit.htm">StrSplit</a></td>
     <td>Separates a string into an array of substrings using the specified delimiters.</td>
   </tr>
   <tr id="WinActive">


### PR DESCRIPTION
the StrLen() link is broken too, v2-changes say the command was removed, but was the func removed?