### PR TITLE
Throw: Rename BadlyCodedFunc() to SomeFunction()

### DIFF
--- a/docs/commands/Throw.htm
+++ b/docs/commands/Throw.htm
@@ -42,11 +42,11 @@ throw { what: &quot;Custom error&quot;, file: A_LineFile, line: A_LineNumber } <
 <p>If <em>What</em> is omitted, it defaults to the name of the current function or subroutine. Otherwise it can be a string or a negative offset from the top of the call stack. For example, a value of -1 sets <code>Exception.What</code> to the current function or subroutine and <code>Exception.Line</code> to the line which called it. However, if the script is <a href="../Scripts.htm#ahk2exe">compiled</a> or the offset is invalid, <em>What</em> is simply converted to a string.</p>
 <p><em>Message</em> and <em>Extra</em> are converted to strings. These are displayed by an error dialog if the exception is thrown and not caught.</p>
 <pre>try
-    BadlyCodedFunc()
+    SomeFunction()
 catch e
     MsgBox % "Error in " e.What ", which was called at line " e.Line 
 
-BadlyCodedFunc() {
+SomeFunction() {
     throw Exception("Fail", -1)
 }</pre>
 


### PR DESCRIPTION
The first time I read this document, I assumed the example BadlyCodedFunc() implied that only badly coded functions should throw exceptions. I gave the function a more generic name to avoid confusion.