### PR TITLE
Click: Add commas for consistent syntax

### DIFF
--- a/docs/commands/Click.htm
+++ b/docs/commands/Click.htm
@@ -19,27 +19,27 @@
     <td>Clicks the left mouse button once at the mouse cursor's current position.</td>
   </tr>
   <tr>
-    <td>Click 44, 55</td>
+    <td>Click, 44, 55</td>
     <td>Clicks the left mouse button once at coordinates 44, 55 (based on <a href="CoordMode.htm">CoordMode</a>).</td>
   </tr>
   <tr>
-    <td>Click right 44, 55</td>
+    <td>Click, right, 44, 55</td>
     <td>Same as above but clicks the right mouse button.</td>
   </tr>
   <tr>
-    <td>Click 2</td>
+    <td>Click, 2</td>
     <td>Clicks the left mouse button twice at the cursor's current position (i.e. double-click).</td>
   </tr>
   <tr>
-    <td>Click down</td>
+    <td>Click, down</td>
     <td>Presses the left mouse button down and holds it.</td>
   </tr>
   <tr>
-    <td>Click up right</td>
+    <td>Click, up, right</td>
     <td>Releases the right mouse button.</td>
   </tr>
   <tr>
-    <td>Click %x% %y%</td>
+    <td>Click, %x%, %y%</td>
     <td>Since click does not support <a href="../Variables.htm#Expressions">expressions</a>, variables should be enclosed in percent signs.</td>
   </tr>
 </table>
@@ -48,16 +48,16 @@
 <p><strong>Button Name:</strong> Left (default), Right, Middle (or just the first letter of each of these); or the fourth or fifth mouse button (X1 or X2). NOTE: Unlike <a href="MouseClick.htm">MouseClick</a>, the left and right buttons behave consistently across all systems, even if the user has swapped the buttons via the system's control panel.</p>
 <p><strong>Mouse Wheel</strong>: Specify WheelUp or WU to turn the wheel upward (away from you); specify WheelDown or WD to turn the wheel downward (toward you). In v1.0.48+, WheelLeft (or WL) or WheelRight (or WR) may also be specified (but they have no effect on older operating systems older than Windows Vista). For <em>ClickCount</em> (below), specify the number of notches to turn the wheel. However, some applications do not obey a <em>ClickCount</em> higher than 1 for the mouse wheel. For them, use a <a href="Loop.htm">Loop</a> such as the following:</p>
 <pre>Loop 5
-    Click WheelUp</pre>
-<p><strong>ClickCount</strong>: The number of times to click the mouse (examples: <code>Click 2</code>, <code>Click 100, 200, 2</code>). If omitted, the button is clicked once. If coordinates are specified, <em>ClickCount</em> must appear after them. Specify zero (0) to move the mouse without clicking (for example: <code>Click 100, 200, 0</code>).</p>
+    Click, WheelUp</pre>
+<p><strong>ClickCount</strong>: The number of times to click the mouse (examples: <code>Click, 2</code>, <code>Click, 100, 200, 2</code>). If omitted, the button is clicked once. If coordinates are specified, <em>ClickCount</em> must appear after them. Specify zero (0) to move the mouse without clicking (for example: <code>Click, 100, 200, 0</code>).</p>
 <p><strong>Down</strong> or <strong>Up:</strong> These words are normally omitted, in which case each click consists of a down-event followed by an up-event. Otherwise, specify <em>Down</em> (or the letter <em>D</em>) to press the mouse button down without releasing it. Later, use the word <em>Up</em> (or the letter <em>U</em>) to release the mouse button.</p>
 <p><strong>Relative:</strong> The word <em>Rel</em> or <em>Relative</em> treats the specified X and Y coordinates as offsets from the current mouse position. In other words, the cursor will be moved from its current position by X pixels to the right (left if negative) and Y pixels down (up if negative).</p>
 <h3>Remarks</h3>
 <p><em>Click</em> is generally preferred over <a href="MouseClick.htm">MouseClick</a> because it automatically compensates if the user has swapped the left and right mouse buttons via the system's control panel.</p>
 <p><em>Click</em> uses the sending method set by <a href="SendMode.htm">SendMode</a>. To override this mode for a particular click, use a specific Send command as in this example: <code><a href="Send.htm#Click">SendEvent {Click, 100, 200}</a></code>.</p>
 <p>To perform a shift-click or control-click, the <code><a href="Send.htm#Click">Send {Click}</a></code> method is generally easiest. For example:</p>
-<pre>Send +{Click 100, 200}  <em>; Shift+LeftClick</em>
-Send ^{Click 100, 200, right}  <em>; Control+RightClick</em></pre>
+<pre>Send +{Click, 100, 200}  <em>; Shift+LeftClick</em>
+Send ^{Click, 100, 200, right}  <em>; Control+RightClick</em></pre>
 <p>Unlike <a href="Send.htm">Send</a>, <em>Click</em> does not automatically release the modifier keys (Control, Alt, Shift, and Win). For example, if the Control key is currently down, <em>Click</em> would produce a control-click but <code>Send {Click}</code> would produce a normal click.</p>
 <p>The <a href="SendMode.htm">SendPlay mode</a> is able to successfully generate mouse events in a broader variety of games than the other modes. In addition, some applications and games may have trouble tracking the mouse if it moves too quickly, in which case <a href="SetDefaultMouseSpeed.htm">SetDefaultMouseSpeed</a> can be used to reduce the speed (but only in <a href="SendMode.htm">SendEvent mode</a>).</p>
 <p>The <a href="BlockInput.htm">BlockInput</a> command can be used to prevent any physical mouse activity by the user from disrupting the simulated mouse events produced by the mouse commands. However, this is generally not needed for the <a href="SendMode.htm">SendInput</a> and <a href="SendMode.htm">SendPlay</a> modes because they automatically postpone the user's physical mouse activity until afterward.</p>
@@ -66,12 +66,12 @@ Send ^{Click 100, 200, right}  <em>; Control+RightClick</em></pre>
 <p><a href="Send.htm#Click">Send {Click}</a>, <a href="SendMode.htm">SendMode</a>, <a href="CoordMode.htm">CoordMode</a>, <a href="SetDefaultMouseSpeed.htm">SetDefaultMouseSpeed</a>, <a href="SetMouseDelay.htm">SetMouseDelay</a>, <a href="MouseClick.htm">MouseClick</a>, <a href="MouseClickDrag.htm">MouseClickDrag</a>, <a href="MouseMove.htm">MouseMove</a>, <a href="ControlClick.htm">ControlClick</a>, <a href="BlockInput.htm">BlockInput</a></p>
 <h3>Examples</h3>
 <pre class="NoIndent">Click  <em>; Click left mouse button at mouse cursor's current position.</em>
-Click 100, 200  <em>; Click left mouse button at specified coordinates.</em>
-Click 100, 200, 0  <em>; Move the mouse without clicking.</em>
-Click 100, 200 right  <em>; Click the right mouse button.</em>
-Click 2  <em>; Perform a double-click.</em>
-Click down  <em>; Presses down the left mouse button and holds it.</em>
-Click up right  <em>; Releases the right mouse button.</em></pre>
+Click, 100, 200  <em>; Click left mouse button at specified coordinates.</em>
+Click, 100, 200, 0  <em>; Move the mouse without clicking.</em>
+Click, 100, 200, right  <em>; Click the right mouse button.</em>
+Click, 2  <em>; Perform a double-click.</em>
+Click, down  <em>; Presses down the left mouse button and holds it.</em>
+Click, up, right  <em>; Releases the right mouse button.</em></pre>
 
 </body>
 </html>


### PR DESCRIPTION
The lack of commas after command parameters is inconsistent with the syntax from other documentation pages. (i.e. `Click 100, 200 right` vs `Click, 100, 200, right`)

While the commas are not *technically* needed, omitting them adds unnecessary ambiguity for novice users. The difference in syntax also makes the transition from MouseClick to Click a bit more confusing.