### PR TITLE
Arrays: Add ref id for Associative Arrays section

### DIFF
--- a/docs/misc/Arrays.htm
+++ b/docs/misc/Arrays.htm
@@ -11,7 +11,7 @@
 <body>
 <h1>Arrays</h1>
 
-<h2>Associative Arrays <span class="ver">[AHK_L 31+]</span></h2>
+<h2 id="Associative_Arrays">Associative Arrays <span class="ver">[AHK_L 31+]</span></h2>
 <p>Self-contained associative arrays can be created by calling <a href="../Objects.htm#Arrays">Object()</a>. For example:</p>
 <pre><em>; Create the array, initially empty:</em>
 Array := Object()
@@ -29,7 +29,7 @@ for index, element in Array <em>; Recommended approach in most cases.</em>
     <em>; Using "Loop", indices must be consecutive numbers from 1 to the number
     ; of elements in the array (or they must be calculated within the loop).
     ; MsgBox % "Element number " . A_Index . " is " . Array[A_Index]
-    
+
     ; Using "for", both the index (or "key") and its associated value
     ; are provided, and the index can be *any* value of your choosing.</em>
     MsgBox % "Element number " . index . " is " . element
@@ -46,7 +46,7 @@ for index, element in Array <em>; Recommended approach in most cases.</em>
 <em>; Array%j%_%k% := A_LoopReadLine</em>
   Array[j, k] := A_LoopReadLine
 
-  ArrayCount := 0                        
+  ArrayCount := 0
   Loop, Read, C:\Guest List.txt
   {
       ArrayCount += 1


### PR DESCRIPTION
- Add ID #Associative_Arrays for section header.
  - Allows hyperlinking with https://autohotkey.com/docs/misc/Arrays.htm#Associative_Arrays
- Trim trailing whitespace