### PR TITLE
 Functions: Clarify that = and := function identically

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -72,7 +72,7 @@
 <pre>Add(X, Y, Z:=0) {
     return X + Y + Z
 }</pre>
-<p>As of v1.1.09, both <code>=</code> and <code>:=</code> are supported and function <strong>identically</strong> to each other. (ie: both interpret values as an <a href="Variables.htm#Expressions">expression</a>) The latter is recommended for consistency with expression assignments and compatibility with future versions of AutoHotkey.</p>
+<p>As of v1.1.09, both <code>=</code> and <code>:=</code> are supported and function <strong>identically</strong> to each other. (ie: both interpret values as an <a href="Variables.htm#Expressions">expression</a>) The latter is recommended for consistency with expression assignments and compatibility with <a href="https://autohotkey.com/v2/">future versions of AutoHotkey</a>.</p>
 <p>When the caller passes <strong>three</strong> parameters to the function above, Z's default value is ignored. But when the caller passes only <strong>two</strong> parameters, Z automatically receives the value 0.</p>
 <p id="missing">It is not possible to have optional parameters isolated in the middle of the parameter list. In other words, all parameters that lie to the right of the first optional parameter must also be marked optional. <span class="ver">[AHK_L 31+]:</span> Optional parameters may be omitted from the middle of the parameter list when calling the function, as shown below. For dynamic function calls and method calls, this requires v1.1.12+.</p>
 <pre>Func(1,, 3)

--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -72,7 +72,7 @@
 <pre>Add(X, Y, Z:=0) {
     return X + Y + Z
 }</pre>
-<p>As of v1.1.09, both <code>=</code> and <code>:=</code> are supported. The latter is recommended for consistency with expression assignments and compatibility with future versions of AutoHotkey.</p>
+<p>As of v1.1.09, both <code>=</code> and <code>:=</code> are supported and function <strong>identically</strong> to each other. (ie: both interpret values as an <a href="Variables.htm#Expressions">expression</a>) The latter is recommended for consistency with expression assignments and compatibility with future versions of AutoHotkey.</p>
 <p>When the caller passes <strong>three</strong> parameters to the function above, Z's default value is ignored. But when the caller passes only <strong>two</strong> parameters, Z automatically receives the value 0.</p>
 <p id="missing">It is not possible to have optional parameters isolated in the middle of the parameter list. In other words, all parameters that lie to the right of the first optional parameter must also be marked optional. <span class="ver">[AHK_L 31+]:</span> Optional parameters may be omitted from the middle of the parameter list when calling the function, as shown below. For dynamic function calls and method calls, this requires v1.1.12+.</p>
 <pre>Func(1,, 3)


### PR DESCRIPTION
On the page for [*Variables and Expressions*](https://autohotkey.com/docs/Variables.htm#Variables_and_Expressions), the `=` operator is described as follows.

> The traditional method uses the equal sign operator (=) to assign **unquoted** literal strings or variables enclosed in percent signs... By contrast, the expression method uses the colon-equal operator (:=) to store numbers, **quoted** strings, and other types of expressions.

To prevent confusion, this note clarifies that the two operators function identically when used to define optional parameters.