### PR TITLE
v2: Fix examples

### DIFF
--- a/docs/commands/DllCall.htm
+++ b/docs/commands/DllCall.htm
@@ -222,19 +222,19 @@ F1 up::<strong>DllCall</strong>(&quot;SystemParametersInfo&quot;, UInt, 0x71, UI
 ; focused control (with real-time updates).</em>
 
 SetTimer "WatchScrollBar", 100
-return
 
-WatchScrollBar:
-ActiveWindow := WinExist(&quot;A&quot;)
-if !ActiveWindow  <em>; No active window.</em>
-    return
-FocusedControl := ControlGetFocus()  <em>; Omit all parameter to use the Last Found Window.</em>
-if !FocusedControl  <em>; No focused control.</em>
-    return
-<em>; Display the vertical or horizontal scroll bar's position in a ToolTip:</em>
-ChildHWND := ControlGetHwnd(FocusedControl)
-ToolTip(<strong>DllCall</strong>("GetScrollPos", "Ptr", ChildHWND, "Int", 1))  <em>;  Last parameter is 1 for SB_VERT, 0 for SB_HORZ.</em>
-return</pre>
+WatchScrollBar()
+{
+    ActiveWindow := WinExist(&quot;A&quot;)
+    if !ActiveWindow  <em>; No active window.</em>
+        return
+    FocusedControl := ControlGetFocus()  <em>; Omit all parameter to use the Last Found Window.</em>
+    if !FocusedControl  <em>; No focused control.</em>
+        return
+    <em>; Display the vertical or horizontal scroll bar's position in a ToolTip:</em>
+    ChildHWND := ControlGetHwnd(FocusedControl)
+    ToolTip(<strong>DllCall</strong>("GetScrollPos", "Ptr", ChildHWND, "Int", 1))  <em>;  Last parameter is 1 for SB_VERT, 0 for SB_HORZ.</em>
+}</pre>
 
 <pre class="NoIndent" id="file"><em>; Example: This is a working script that writes some text to a file then reads it back into memory.
 ; This method can be used to help performance in cases where multiple files are being read or written simultaneously.

--- a/docs/commands/FileMove.htm
+++ b/docs/commands/FileMove.htm
@@ -22,8 +22,8 @@
 
   <dt>DestPattern</dt>
   <dd><p>The name or pattern of the  destination, which is assumed to be in <a href="../Variables.htm#WorkingDir">A_WorkingDir</a> if an absolute path isn't specified.  To perform a simple move -- retaining the existing file name(s) -- specify only the folder name as shown in these functionally identical examples:</p>
-<pre>FileMove "C:\*.txt, C:\My Folder"</pre>
-<pre>FileMove "C:\*.txt, C:\My Folder\*.*"</pre>
+<pre>FileMove "C:\*.txt", "C:\My Folder"</pre>
+<pre>FileMove "C:\*.txt", "C:\My Folder\*.*"</pre>
     </dd>
 
   <dt>Flag</dt>

--- a/docs/commands/Gosub.htm
+++ b/docs/commands/Gosub.htm
@@ -34,7 +34,7 @@
 <p><a href="Return.htm">Return</a>, <a href="../Functions.htm">Functions</a>, <a href="IsLabel.htm">IsLabel</a>, <a href="Block.htm">Blocks</a>, <a href="Loop.htm">Loop</a>, <a href="Goto.htm">Goto</a></p>
 
 <h3>Example</h3>
-<pre class="NoIndent">Gosub, Label1 
+<pre class="NoIndent">Gosub Label1
 MsgBox "The Label1 subroutine has returned (it is finished)."
 return
 

--- a/docs/commands/GroupAdd.htm
+++ b/docs/commands/GroupAdd.htm
@@ -60,9 +60,9 @@ Numpad1::GroupActivate "MSIE", "r"
 ; In the autoexecute section at the top of the script:</em>
 SetTitleMatchMode 2 
 GroupAdd "mail", "Message - Microsoft Word" <em>; This is for mails currently being composed</em>
-GroupAdd "mail", "- Message" ( <em>; This is for already opened items 
+GroupAdd "mail", "- Message (" <em>; This is for already opened items 
 ; Need extra text to avoid activation of a phantom window:</em>
-GroupAdd "mail, "Advanced Find", "Sear&amp;ch for the word(s)"
+GroupAdd "mail", "Advanced Find", "Sear&amp;ch for the word(s)"
 GroupAdd "mail", , "Recurrence:"
 GroupAdd "mail", "Reminder"
 GroupAdd "mail", "- Microsoft Outlook"

--- a/docs/commands/GuiControls.htm
+++ b/docs/commands/GuiControls.htm
@@ -562,7 +562,7 @@ IPCtrlSetAddress(hControl, IPAddress)
 
     <em>; Pack the IP address into a 32-bit word for use with SendMessage.</em>
     IPAddrWord := 0
-    Loop Parse IPAddress, .
+    Loop Parse IPAddress, "."
         IPAddrWord := (IPAddrWord * 256) + A_LoopField
     SendMessage(IPM_SETADDRESS, 0, IPAddrWord,, "ahk_id " hControl)
 }

--- a/docs/commands/Hotstring.htm
+++ b/docs/commands/Hotstring.htm
@@ -13,8 +13,8 @@
 
 <p>Creates, modifies, enables, or disables a <a href="../Hotstrings.htm">hotstring</a> while the script is running.</p>
 
-<pre class="Syntax"><span class="func">Hotstring</span>(String <span class="optional">, Replacement, OnOffToggle</span>)
-<span class="func">Hotstring</span>(<a href="#NewOptions">NewOptions</a>)
+<pre class="Syntax"><span class="func">Hotstring</span> String <span class="optional">, Replacement, OnOffToggle</span>
+<span class="func">Hotstring</span> <a href="#NewOptions">NewOptions</a>
 OldValue := <span class="func">Hotstring</span>("<a href="#EndChars">EndChars</a>" <span class="optional">, NewValue</span>)
 OldValue := <span class="func">Hotstring</span>("<a href="#MouseReset">MouseReset</a>" <span class="optional">, NewValue</span>)</pre>
 <h3>Parameters</h3>
@@ -23,7 +23,7 @@ OldValue := <span class="func">Hotstring</span>("<a href="#MouseReset">MouseRese
   <dt>String</dt>
   <dd>
     <p>The hotstring's trigger string, preceded by <a href="../Hotstrings.htm">the usual colons</a> and <a href="../Hotstrings.htm#Options">option characters</a>. For example, <code>"::btw"</code> or <code>":*:]d"</code>.</p>
-    <p><em>String</em> may be matched to an existing hotstring by considering <a href="../Hotstrings.htm#C">case-sensitivity (C)</a>, <a href="../Hotstrings.htm#Question">word-sensitivity (?)</a>, activation criteria (as set by <a href="_If.htm">#If</a> or <a href="Hotkey.htm#if">Hotkey, If</a>) and the trigger string. For example, <code>"::btw"</code> and <code>"::BTW"</code> match unless the case-sensitive mode was enabled as a default, while <code>":C:btw"</code> and <code>":C:BTW"</code> never match. The <code>C</code> and <code>?</code> options may be included in <em>String</em> or set as defaults by the <a href="_Hotstring.htm">#Hotstring</a> directive or a previous call to <a href="#NewOptions">this function</a>.</p>
+    <p><em>String</em> may be matched to an existing hotstring by considering <a href="../Hotstrings.htm#C">case-sensitivity (C)</a>, <a href="../Hotstrings.htm#Question">word-sensitivity (?)</a>, activation criteria (as set by <a href="_If.htm">#If</a> or <a href="Hotkey.htm#if">Hotkey "If"</a>) and the trigger string. For example, <code>"::btw"</code> and <code>"::BTW"</code> match unless the case-sensitive mode was enabled as a default, while <code>":C:btw"</code> and <code>":C:BTW"</code> never match. The <code>C</code> and <code>?</code> options may be included in <em>String</em> or set as defaults by the <a href="_Hotstring.htm">#Hotstring</a> directive or a previous call to <a href="#NewOptions">this function</a>.</p>
     <p>If the hotstring already exists, any options specified in <em>String</em> are put into effect, while all other options are left as is. However, since hotstrings with <code>C</code> or <code>?</code> are considered distinct from other hotstrings, it is not possible to add or remove these options. Instead, turn off the existing hotstring and create a new one.</p>
     <p>When a hotstring is first created -- either by the Hotstring function or a <a href="../Hotstrings.htm">double-colon label</a> in the script -- its trigger string and sequence of option characters becomes the permanent name of that hotstring as reflected by <a href="../Variables.htm#ThisHotkey">A_ThisHotkey</a>. This name does not change even if the Hotstring function later accesses the hotstring with different option characters.</p>
     <p>If the <a href="../Hotstrings.htm#X">X (execute) option</a> is present in <em>String</em> (not just set as a default), the <em>Replacement</em> parameter is interpreted as a label or function name instead of replacement text. This has no effect if <em>Replacement</em> is an object.</p>
@@ -51,9 +51,9 @@ OldValue := <span class="func">Hotstring</span>("<a href="#MouseReset">MouseRese
 <p>This function throws an exception if the parameters are invalid or a memory allocation fails. It does not affect <a href="../misc/ErrorLevel.htm">ErrorLevel</a>.</p>
 <p>An exception is also thrown if <em>Replacement</em> is omitted and <em>String</em> is valid but does not match an existing hotstring. This can be utilized to test for the existence of a hotstring. For example:</p>
 <pre>try
-    Hotstring("::btw")
+    Hotstring "::btw"
 catch
-    MsgBox The hotstring does not exist or it has no variant for the current IfWin criteria.</pre>
+    MsgBox "The hotstring does not exist or it has no variant for the current IfWin criteria."</pre>
 
 <h3>Remarks</h3>
 <p>The <a href="Hotkey.htm#IfWin">current IfWin setting</a> determines the <a href="#variant">variant</a> of a hotstring upon which the Hotstring function will operate.</p>
@@ -65,12 +65,12 @@ catch
 
 <h3 id="variant">Variant (Duplicate) Hotstrings</h3>
 <p>A particular hotstring can be created more than once if each definition has different IfWin criteria, <a href="../Hotstrings.htm#C">case-sensitivity</a> (<code>C</code> vs. <code>C0</code>/<code>C1</code>), or <a href="../Hotstrings.htm#Question">word-sensitivity</a> (<code>?</code>). These are known as <em>hotstring variants</em>. For example:</p>
-<pre><a href="Hotkey.htm#IfWin">Hotkey, IfWinActive</a>, ahk_group CarForums
-Hotstring("::btw", "behind the wheel")
-Hotkey, IfWinActive, Inter-Office Chat
-Hotstring("::btw", "back to work")
-Hotkey, IfWinActive
-Hotstring("::btw", "by the way")</pre>
+<pre><a href="Hotkey.htm#IfWin">Hotkey "IfWinActive"</a>, "ahk_group CarForums"
+Hotstring "::btw", "behind the wheel"
+Hotkey "IfWinActive", "Inter-Office Chat"
+Hotstring "::btw", "back to work"
+Hotkey "IfWinActive"
+Hotstring "::btw", "by the way"</pre>
 <p>If more than one variant of a hotstring is eligible to fire, only the one created earliest will fire.</p>
 <p>For more information about IfWin, see <a href="_If.htm#general-remarks">#If's General Remarks</a>.</p>
 
@@ -78,7 +78,7 @@ Hotstring("::btw", "by the way")</pre>
 <pre class="Syntax">OldValue := <span class="func">Hotstring</span>("EndChars" <span class="optional">, NewValue</span>)</pre>
 <p>Retrieves or modifies the set of characters used as <a href="../Hotstrings.htm#EndChars">ending characters</a> by the hotstring recognizer. For example:</p>
 <pre>prev_chars := Hotstring("EndChars", "-()[]{}':;""/\,.?!`n `t")
-MsgBox The previous value was: %prev_chars%</pre>
+MsgBox "The previous value was: " prev_chars</pre>
 <p><a href="Hotstring.htm#EndChars">#Hotstring EndChars</a> also affects this setting.</p>
 <p>It is currently not possible to specify a different set of end characters for each hotstring.</p>
 
@@ -89,9 +89,9 @@ MsgBox The previous value was: %prev_chars%</pre>
 <p><a href="_Hotstring.htm">#Hotstring NoMouse</a> also affects this setting, and is equivalent to specifying <code>false</code> for <em>NewValue</em>.</p>
 
 <h3 id="NewOptions">Setting Default Options</h3>
-<pre class="Syntax"><span class="func">Hotstring</span>(NewOptions)</pre>
-<p>To set new default options for subsequently created hotstrings, pass the options to the Hotstring function without any leading or trailing colon. For example: <code>Hotstring("T")</code>.</p>
-<p>Turning on <a href="../Hotstrings.htm#C">case-sensitivity (C)</a> or <a href="../Hotstrings.htm#Question">word-sensitivity (?)</a> also affects which existing hotstrings will be found by any subsequent calls to the Hotstring function. For example, <code>Hotstring(":T:btw")</code> will find <code>::BTW</code> by default, but not if <code>Hotstring("C")</code> or <code><a href="_Hotstring.htm">#Hotstring</a> C</code> is in effect. This can be undone or overridden by passing a mutually-exclusive option; for example, <code>C0</code> and <code>C1</code> override <code>C</code>.</p>
+<pre class="Syntax"><span class="func">Hotstring</span> NewOptions</pre>
+<p>To set new default options for subsequently created hotstrings, pass the options to the Hotstring function without any leading or trailing colon. For example: <code>Hotstring "T"</code>.</p>
+<p>Turning on <a href="../Hotstrings.htm#C">case-sensitivity (C)</a> or <a href="../Hotstrings.htm#Question">word-sensitivity (?)</a> also affects which existing hotstrings will be found by any subsequent calls to the Hotstring function. For example, <code>Hotstring ":T:btw"</code> will find <code>::BTW</code> by default, but not if <code>Hotstring "C"</code> or <code><a href="_Hotstring.htm">#Hotstring</a> C</code> is in effect. This can be undone or overridden by passing a mutually-exclusive option; for example, <code>C0</code> and <code>C1</code> override <code>C</code>.</p>
 
 <h3>Related</h3>
 <p><a href="../Hotstrings.htm">Hotstrings</a>, <a href="_If.htm">#If</a>, <a href="_MaxThreadsPerHotkey.htm">#MaxThreadsPerHotkey</a>, <a href="Suspend.htm">Suspend</a>, <a href="../misc/Threads.htm">Threads</a>, <a href="Thread.htm">Thread</a>, <a href="Critical.htm">Critical</a></p>

--- a/docs/commands/LoopFiles.htm
+++ b/docs/commands/LoopFiles.htm
@@ -134,7 +134,7 @@ FileList := &quot;&quot;  <em>; Initialize to be blank.</em>
 Loop Files, "C:\*.*"
     FileList .= A_LoopFileName &quot;`n&quot;
 FileList := Sort(FileList, "R")  <em>; The R option sorts in reverse order. See <a href="Sort.htm">Sort</a> for other options.</em>
-Loop, Parse, FileList, "`n"
+Loop Parse, FileList, "`n"
 {
     if A_LoopField = &quot;&quot;  <em>; Ignore the blank item at the end of the list.</em>
         continue

--- a/docs/commands/LoopParse.htm
+++ b/docs/commands/LoopParse.htm
@@ -68,7 +68,7 @@ until Result = "No"</pre>
 <pre class="NoIndent"><em>; Example #3: This is the same as the example above except that it's for the clipboard.
 ; It's useful whenever the clipboard contains files, such as those copied from an open
 ; Explorer window (the program automatically converts such files to their file names):</em>
-Loop parse, clipboard, `n, `r
+Loop parse, clipboard, "`n", "`r"
 {
     Result := MsgBox("File number " A_Index " is " A_LoopField ".`n`nContinue?",, "y/n")
 }

--- a/docs/commands/MenuSelect.htm
+++ b/docs/commands/MenuSelect.htm
@@ -62,7 +62,7 @@
 <p><em>Menu</em> can be <code>0&amp;</code> to select an item within the window's system menu, which typically appears when the user presses Alt+Space or clicks on the icon in the window's title bar. For example:</p>
 <pre><em>; Paste a command into cmd.exe without activating the window.</em>
 Clipboard := "echo Hello, world!`r"
-WinMenuSelectItem ahk_exe cmd.exe,, 0&amp;, Edit, Paste</pre>
+MenuSelect "ahk_exe cmd.exe",, "0&amp;", "Edit", "Paste"</pre>
 <p class="warning"><strong>Caution:</strong> Use this only on windows which have custom items in their system menu.</p>
 <p>If the window does not already have a custom system menu, a copy of the standard system menu will be created and assigned to the target window as a side effect. This copy is destroyed by the system when the script exits, leaving other scripts unable to access it. Therefore, avoid using 0&amp; for the standard items which appear on all windows. Instead, post the <a href="https://msdn.microsoft.com/library/ms646360">WM_SYSCOMMAND</a> message directly. For example:</p>
 <pre><em>; Like "<a href="WinMinimize.htm">WinMinimize</a> A", but also play the system sound for minimizing.</em>

--- a/docs/commands/MouseGetPos.htm
+++ b/docs/commands/MouseGetPos.htm
@@ -48,18 +48,18 @@ MsgBox "The cursor is at X" xpos " Y" ypos
 <em>; This example allows you to move the mouse around to see
 ; the title of the window currently under the cursor:</em>
 SetTimer "WatchCursor", 100
-return
 
-WatchCursor:
-MouseGetPos , , id, control
-ToolTip
-(
-  "ahk_id " id "
-  ahk_class " WinGetClass("ahk_id " id) "
-  " WinGetTitle("ahk_id " id) "
-  Control: " control
-)
-return</pre>
+WatchCursor()
+{
+    MouseGetPos , , id, control
+    ToolTip
+    (
+      "ahk_id " id "
+      ahk_class " WinGetClass("ahk_id " id) "
+      " WinGetTitle("ahk_id " id) "
+      Control: " control
+    )
+}</pre>
 
 </body>
 </html>

--- a/docs/commands/SetTimer.htm
+++ b/docs/commands/SetTimer.htm
@@ -75,7 +75,6 @@
 <h3>Examples</h3>
 <pre class="NoIndent" id="ExampleClose"><em>; Example #1: Close unwanted windows whenever they appear:</em>
 SetTimer "CloseMailWarnings", 250
-return
 
 CloseMailWarnings()
 {
@@ -85,7 +84,6 @@ CloseMailWarnings()
 <p>&nbsp;</p>
 <pre class="NoIndent" id="ExampleWait"><em>; Example #2: Wait for a certain window to appear and then alert the user:</em>
 SetTimer "Alert1", 500
-return
 
 Alert1()
 {

--- a/docs/commands/ToolTip.htm
+++ b/docs/commands/ToolTip.htm
@@ -45,12 +45,7 @@
 <em>; To have a ToolTip disappear after a certain amount of time
 ; without having to use Sleep (which stops the current thread):</em>
 ToolTip "Timed ToolTip`nThis will be displayed for 5 seconds."
-SetTimer "RemoveToolTip", -5000
-return
-
-RemoveToolTip:
-ToolTip
-return</pre>
+SetTimer () => ToolTip(), -5000</pre>
 
 </body>
 </html>

--- a/docs/commands/TrayTip.htm
+++ b/docs/commands/TrayTip.htm
@@ -95,12 +95,12 @@ HideTrayTip() {  <em>; NOTE: For Windows 10, replace this function with the one 
 ; NOTE: This probably won't work well on Windows 10 for <a href="#Windows10">reasons described above</a>.</em>
 #Persistent
 SetTimer "RefreshTrayTip", 1000
-Gosub RefreshTrayTip  <em>; Call it once to get it started right away.</em>
-return
+RefreshTrayTip  <em>; Call it once to get it started right away.</em>
 
-RefreshTrayTip:
-TrayTip "This is a more permanent TrayTip.", "Refreshed TrayTip", "Mute"
-return</pre>
+RefreshTrayTip()
+{
+    TrayTip "This is a more permanent TrayTip.", "Refreshed TrayTip", "Mute"
+}</pre>
 
 </body>
 </html>

--- a/docs/commands/WinMove.htm
+++ b/docs/commands/WinMove.htm
@@ -57,7 +57,7 @@ Gui := GuiCreate("ToolWindow -Sysmenu Disabled", "The clipboard contains:")
 Gui.Add("Text",, Clipboard)
 Gui.Show("w400 h300")
 WinMove 0, 0,,, Gui.Title <em>; Move the splash window to the top left corner.</em>
-MsBbox "Press OK to dismiss the GUI window"
+MsgBox "Press OK to dismiss the GUI window"
 Gui.Destroy
 
 <em>; The following <a href="../Functions.htm">function</a> centers the specified window on the screen:</em>

--- a/docs/commands/WinSet.htm
+++ b/docs/commands/WinSet.htm
@@ -142,13 +142,13 @@ WinSetExStyle "^0x80", <i>WinTitle</i>  <em>; Toggle the WS_EX_TOOLWINDOW attrib
 WinSetTransparent 150, "ahk_class BaseBar"  <em>; To make the Start Menu's submenus transparent, also include the script below.</em></pre>
 <p>To make all or selected menus on the entire system transparent, keep a script such as the following always running. Note that although such a script cannot make its own menus transparent, it can make those of other scripts transparent:</p>
 <pre>SetTimer "WatchForMenu", 5
-return  <em>; End of auto-execute section.</em>
 
-WatchForMenu:
-DetectHiddenWindows True  <em>; Might allow detection of menu sooner.</em>
-if WinExist("ahk_class #32768")
-    WinSetTransparent 150  <em>; Uses the window found by the above line.</em>
-return</pre>
+WatchForMenu()
+{
+    DetectHiddenWindows True  <em>; Might allow detection of menu sooner.</em>
+    if WinExist("ahk_class #32768")
+        WinSetTransparent 150  <em>; Uses the window found by the above line.</em>
+}</pre>
 <p><strong>Related:</strong> <a href="#Parameters">Window Parameters</a>, <a href="#return">Return Value</a>, <a href="WinGet.htm#Transparent">WinGetTransparent</a></p>
 
 <h3 id="TransColor">WinSetTransColor</h3>

--- a/docs/misc/RemapJoystick.htm
+++ b/docs/misc/RemapJoystick.htm
@@ -55,13 +55,14 @@ Send "{LButton down}"   <em>; Hold down the left mouse button.</em>
 SetTimer "WaitForButtonUp3", 10
 return
 
-WaitForButtonUp3:
-if <a href="../commands/GetKeyState.htm">GetKeyState</a>(&quot;Joy3&quot;)  <em>; The button is still, down, so keep waiting.</em>
-    return
-<em>; Otherwise, the button has been released.</em>
-Send "{LButton up}"  <em>; Release the left mouse button.</em>
-SetTimer , "Off"
-return
+WaitForButtonUp3()
+{
+    if <a href="../commands/GetKeyState.htm">GetKeyState</a>(&quot;Joy3&quot;)  <em>; The button is still, down, so keep waiting.</em>
+        return
+    <em>; Otherwise, the button has been released.</em>
+    Send "{LButton up}"  <em>; Release the left mouse button.</em>
+    SetTimer , "Off"
+}
 </pre>
 <br>
 <p><strong>Auto-repeating a keystroke</strong>: Some programs or games might require a key to be sent repeatedly (as though you are holding it down on the keyboard). The following example achieves this by sending spacebar keystrokes repeatedly while you hold down the joystick's second button:</p>
@@ -70,83 +71,84 @@ Send "{Space down}"   <em>; Press the spacebar down.</em>
 SetTimer "WaitForJoy2", <strong>30</strong>  <em>; Reduce the number <strong>30</strong> to 20 or 10 to send keys faster. Increase it to send slower.</em>
 return
 
-WaitForJoy2:
-if not GetKeyState(&quot;Joy2&quot;)  <em>; The button has been released.</em>
+WaitForJoy2()
 {
-    Send "{Space up}"  <em>; Release the spacebar.</em>
-    SetTimer , "Off"  <em>; Stop monitoring the button.</em>
-    return
-}
-<em>; Since above didn't &quot;return&quot;, the button is still being held down.</em>
-Send "{Space down}"  <em>; Send another Spacebar keystroke.</em>
-return</pre>
+    if not GetKeyState(&quot;Joy2&quot;)  <em>; The button has been released.</em>
+    {
+        Send "{Space up}"  <em>; Release the spacebar.</em>
+        SetTimer , "Off"  <em>; Stop monitoring the button.</em>
+        return
+    }
+    <em>; Since above didn't &quot;return&quot;, the button is still being held down.</em>
+    Send "{Space down}"  <em>; Send another Spacebar keystroke.</em>
+}</pre>
 <p><strong>Context-sensitive Joystick Buttons</strong>: The <a href="../commands/_If.htm">#If</a> directive can be used to make selected joystick buttons perform a different action (or none at all) depending on any condition, such as the type of window that is active.</p>
 <p><strong>Using a Joystick as a Mouse</strong>: The <a href="../scripts/JoystickMouse.htm">Joystick-To-Mouse script</a> converts a joystick into a mouse by remapping its buttons and axis control.</p>
 <h2 id="axis">Making a Joystick Axis or POV Hat Send Keystrokes or Mouse Clicks</h2>
 <p>To have a script respond to movement of a joystick's axis or POV hat, use <a href="../commands/SetTimer.htm">SetTimer</a> and <a href="../commands/GetKeyState.htm">GetKeyState</a>. The following example makes the joystick's X and Y axes behave like the arrow key cluster on a keyboard (left, right, up, and down):</p>
 <pre><a href="../commands/SetTimer.htm">SetTimer</a> "WatchAxis", 5
-return
 
-WatchAxis:
-JoyX := <a href="../commands/GetKeyState.htm">GetKeyState</a>("JoyX")  <em>; Get position of X axis.</em>
-JoyY := GetKeyState("JoyY")  <em>; Get position of Y axis.</em>
-KeyToHoldDownPrev := KeyToHoldDown  <em>; Prev now holds the key that was down before (if any).</em>
+WatchAxis()
+{
+    JoyX := <a href="../commands/GetKeyState.htm">GetKeyState</a>("JoyX")  <em>; Get position of X axis.</em>
+    JoyY := GetKeyState("JoyY")  <em>; Get position of Y axis.</em>
+    KeyToHoldDownPrev := KeyToHoldDown  <em>; Prev now holds the key that was down before (if any).</em>
 
-if JoyX &gt; 70
-    KeyToHoldDown := "Right"
-else if JoyX &lt; 30
-    KeyToHoldDown := "Left"
-else if JoyY &gt; 70
-    KeyToHoldDown := "Down"
-else if JoyY &lt; 30
-    KeyToHoldDown := "Up"
-else
-    KeyToHoldDown := ""
+    if JoyX &gt; 70
+        KeyToHoldDown := "Right"
+    else if JoyX &lt; 30
+        KeyToHoldDown := "Left"
+    else if JoyY &gt; 70
+        KeyToHoldDown := "Down"
+    else if JoyY &lt; 30
+        KeyToHoldDown := "Up"
+    else
+        KeyToHoldDown := ""
 
-if KeyToHoldDown = KeyToHoldDownPrev  <em>; The correct key is already down (or no key is needed).</em>
-    return  <em>; Do nothing.</em>
+    if KeyToHoldDown = KeyToHoldDownPrev  <em>; The correct key is already down (or no key is needed).</em>
+        return  <em>; Do nothing.</em>
 
-<em>; Otherwise, release the previous key and press down the new key:</em>
-SetKeyDelay -1  <em>; Avoid delays between keystrokes.</em>
-if KeyToHoldDownPrev   <em>; There is a previous key to release.</em>
-    Send "{" KeyToHoldDownPrev " up}"  <em>; Release it.</em>
-if KeyToHoldDown   <em>; There is a key to press down.</em>
-    Send "{" KeyToHoldDown " down}"  <em>; Press it down.</em>
-return</pre>
+    <em>; Otherwise, release the previous key and press down the new key:</em>
+    SetKeyDelay -1  <em>; Avoid delays between keystrokes.</em>
+    if KeyToHoldDownPrev   <em>; There is a previous key to release.</em>
+        Send "{" KeyToHoldDownPrev " up}"  <em>; Release it.</em>
+    if KeyToHoldDown   <em>; There is a key to press down.</em>
+        Send "{" KeyToHoldDown " down}"  <em>; Press it down.</em>
+}</pre>
 <p>&nbsp;</p>
 <p>The following example makes the joystick's POV hat behave like the arrow key cluster on a keyboard; that is, the POV hat will send arrow keystrokes (left, right, up, and down):</p>
 <pre>SetTimer "WatchPOV", 5
-return
 
-WatchPOV:
-POV := GetKeyState("JoyPOV")  <em>; Get position of the POV control.</em>
-KeyToHoldDownPrev := KeyToHoldDown  <em>; Prev now holds the key that was down before (if any).</em>
+WatchPOV()
+{
+    POV := GetKeyState("JoyPOV")  <em>; Get position of the POV control.</em>
+    KeyToHoldDownPrev := KeyToHoldDown  <em>; Prev now holds the key that was down before (if any).</em>
 
-<em>; Some joysticks might have a smooth/continous POV rather than one in fixed increments.
-; To support them all, use a range:</em>
-if POV &lt; 0   <em>; No angle to report</em>
-    KeyToHoldDown := ""
-else if POV &gt; 31500                <em>; 315 to 360 degrees: Forward</em>
-    KeyToHoldDown := "Up"
-else if POV &gt;= 0 and POV &lt;= 4500      <em>; 0 to 45 degrees: Forward</em>
-    KeyToHoldDown := "Up"
-else if POV &gt;= 4501 and POV &lt;= 13500  <em>; 45 to 135 degrees: Right</em>
-    KeyToHoldDown := "Right"
-else if POV &gt;= 13501 and POV &lt;= 22500 <em>; 135 to 225 degrees: Down</em>
-    KeyToHoldDown := "Down"
-else                                  <em>; 225 to 315 degrees: Left</em>
-    KeyToHoldDown := "Left"
+    <em>; Some joysticks might have a smooth/continous POV rather than one in fixed increments.
+    ; To support them all, use a range:</em>
+    if POV &lt; 0   <em>; No angle to report</em>
+        KeyToHoldDown := ""
+    else if POV &gt; 31500                <em>; 315 to 360 degrees: Forward</em>
+        KeyToHoldDown := "Up"
+    else if POV &gt;= 0 and POV &lt;= 4500      <em>; 0 to 45 degrees: Forward</em>
+        KeyToHoldDown := "Up"
+    else if POV &gt;= 4501 and POV &lt;= 13500  <em>; 45 to 135 degrees: Right</em>
+        KeyToHoldDown := "Right"
+    else if POV &gt;= 13501 and POV &lt;= 22500 <em>; 135 to 225 degrees: Down</em>
+        KeyToHoldDown := "Down"
+    else                                  <em>; 225 to 315 degrees: Left</em>
+        KeyToHoldDown := "Left"
 
-if KeyToHoldDown = KeyToHoldDownPrev  <em>; The correct key is already down (or no key is needed).</em>
-    return  <em>; Do nothing.</em>
+    if KeyToHoldDown = KeyToHoldDownPrev  <em>; The correct key is already down (or no key is needed).</em>
+        return  <em>; Do nothing.</em>
 
-<em>; Otherwise, release the previous key and press down the new key:</em>
-SetKeyDelay -1  <em>; Avoid delays between keystrokes.</em>
-if KeyToHoldDownPrev   <em>; There is a previous key to release.</em>
-    Send "{" KeyToHoldDownPrev " up}"  <em>; Release it.</em>
-if KeyToHoldDown   <em>; There is a key to press down.</em>
-    Send "{" KeyToHoldDown " down}"  <em>; Press it down.</em>
-return</pre>
+    <em>; Otherwise, release the previous key and press down the new key:</em>
+    SetKeyDelay -1  <em>; Avoid delays between keystrokes.</em>
+    if KeyToHoldDownPrev   <em>; There is a previous key to release.</em>
+        Send "{" KeyToHoldDownPrev " up}"  <em>; Release it.</em>
+    if KeyToHoldDown   <em>; There is a key to press down.</em>
+        Send "{" KeyToHoldDown " down}"  <em>; Press it down.</em>
+}</pre>
 <p>&nbsp;</p>
 <p><strong>Auto-repeating a keystroke</strong>: Both examples above can be modified to send the key repeatedly rather than merely holding it down (that is, they can mimic physically holding down a key on the keyboard). To do this, replace the following line:</p>
 <pre>return  <em>; Do nothing.</em></pre>

--- a/docs/objects/Gui.htm
+++ b/docs/objects/Gui.htm
@@ -529,17 +529,11 @@ WM_MOUSEMOVE(wParam, lParam, msg, Hwnd)
     if CurrControl
     {
       Text := %CurrControl.Name%_TT
-      SetTimer("DisplayToolTip", -1000)
+      SetTimer () => ToolTip(Text), -1000
+      SetTimer () => ToolTip(), -4000 <em>; Remove the tooltip.</em>
     }
     PrevHwnd := Hwnd
   }
-}
-
-DisplayToolTip()
-{
-  global
-  ToolTip(Text)
-  SetTimer("ToolTip", -3000) <em>; Remove the tooltip.</em>
 }
 
 Gui_Close()
@@ -556,7 +550,7 @@ Gui.SetFont("s32")  <em>; Set a large font size (32-point).</em>
 CoordText := Gui.Add("Text", "cLime", "XXXXX YYYYY")  <em>; XX &amp; YY serve to auto-size the window.
 ; Make all pixels of this color transparent and make the text itself translucent (150):</em>
 WinSetTransColor(Gui.BackColor " 150")
-fn := Func("UpdateOSD").bind(CoordText), SetTimer(fn, 200)
+SetTimer(Func("UpdateOSD").bind(CoordText), 200)
 UpdateOSD(CoordText)  <em>; Make the first update immediate rather than waiting for the timer.</em>
 Gui.Show("x0 y400 NoActivate")  <em>; NoActivate avoids deactivating the currently active window.</em>
 

--- a/docs/scripts/EasyWindowDrag.ahk
+++ b/docs/scripts/EasyWindowDrag.ahk
@@ -10,32 +10,35 @@
 
 ~MButton & LButton::
 CapsLock & LButton::
-CoordMode "Mouse"  ; Switch to screen/absolute coordinates.
-MouseGetPos EWD_MouseStartX, EWD_MouseStartY, EWD_MouseWin
-WinGetPos EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
-if !WinGetMinMax("ahk_id " EWD_MouseWin)  ; Only if the window isn't maximized 
-    SetTimer "EWD_WatchMouse", 10 ; Track the mouse as the user drags it.
-return
+EWD_MoveWindow()
+{
+    CoordMode "Mouse"  ; Switch to screen/absolute coordinates.
+    MouseGetPos EWD_MouseStartX, EWD_MouseStartY, EWD_MouseWin
+    WinGetPos EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
+    if !WinGetMinMax("ahk_id " EWD_MouseWin)  ; Only if the window isn't maximized 
+        SetTimer "EWD_WatchMouse", 10 ; Track the mouse as the user drags it.
 
-EWD_WatchMouse:
-if !GetKeyState("LButton", "P")  ; Button has been released, so drag is complete.
-{
-    SetTimer , "Off"
-    return
+    EWD_WatchMouse()
+    {
+        if !GetKeyState("LButton", "P")  ; Button has been released, so drag is complete.
+        {
+            SetTimer , "Off"
+            return
+        }
+        if GetKeyState("Escape", "P")  ; Escape has been pressed, so drag is cancelled.
+        {
+            SetTimer , "Off"
+            WinMove EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
+            return
+        }
+        ; Otherwise, reposition the window to match the change in mouse coordinates
+        ; caused by the user having dragged the mouse:
+        CoordMode "Mouse"
+        MouseGetPos EWD_MouseX, EWD_MouseY
+        WinGetPos EWD_WinX, EWD_WinY,,, "ahk_id " EWD_MouseWin
+        SetWinDelay -1   ; Makes the below move faster/smoother.
+        WinMove EWD_WinX + EWD_MouseX - EWD_MouseStartX, EWD_WinY + EWD_MouseY - EWD_MouseStartY,,, "ahk_id " EWD_MouseWin
+        EWD_MouseStartX := EWD_MouseX  ; Update for the next timer-call to this subroutine.
+        EWD_MouseStartY := EWD_MouseY
+    }
 }
-if GetKeyState("Escape", "P")  ; Escape has been pressed, so drag is cancelled.
-{
-    SetTimer , "Off"
-    WinMove EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
-    return
-}
-; Otherwise, reposition the window to match the change in mouse coordinates
-; caused by the user having dragged the mouse:
-CoordMode "Mouse"
-MouseGetPos EWD_MouseX, EWD_MouseY
-WinGetPos EWD_WinX, EWD_WinY,,, "ahk_id " EWD_MouseWin
-SetWinDelay -1   ; Makes the below move faster/smoother.
-WinMove EWD_WinX + EWD_MouseX - EWD_MouseStartX, EWD_WinY + EWD_MouseY - EWD_MouseStartY,,, "ahk_id " EWD_MouseWin
-EWD_MouseStartX := EWD_MouseX  ; Update for the next timer-call to this subroutine.
-EWD_MouseStartY := EWD_MouseY
-return

--- a/docs/scripts/EasyWindowDrag.htm
+++ b/docs/scripts/EasyWindowDrag.htm
@@ -23,35 +23,38 @@
 
 ~MButton & LButton::
 CapsLock & LButton::
-CoordMode "Mouse"  <em>; Switch to screen/absolute coordinates.</em>
-MouseGetPos EWD_MouseStartX, EWD_MouseStartY, EWD_MouseWin
-WinGetPos EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
-if !WinGetMinMax("ahk_id " EWD_MouseWin)  <em>; Only if the window isn't maximized </em>
-    SetTimer "EWD_WatchMouse", 10 <em>; Track the mouse as the user drags it.</em>
-return
+EWD_MoveWindow()
+{
+    CoordMode "Mouse"  <em>; Switch to screen/absolute coordinates.</em>
+    MouseGetPos EWD_MouseStartX, EWD_MouseStartY, EWD_MouseWin
+    WinGetPos EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
+    if !WinGetMinMax("ahk_id " EWD_MouseWin)  <em>; Only if the window isn't maximized </em>
+        SetTimer "EWD_WatchMouse", 10 <em>; Track the mouse as the user drags it.</em>
 
-EWD_WatchMouse:
-if !GetKeyState("LButton", "P")  <em>; Button has been released, so drag is complete.</em>
-{
-    SetTimer , "Off"
-    return
+    EWD_WatchMouse()
+    {
+        if !GetKeyState("LButton", "P")  <em>; Button has been released, so drag is complete.</em>
+        {
+            SetTimer , "Off"
+            return
+        }
+        if GetKeyState("Escape", "P")  <em>; Escape has been pressed, so drag is cancelled.</em>
+        {
+            SetTimer , "Off"
+            WinMove EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
+            return
+        }
+        <em>; Otherwise, reposition the window to match the change in mouse coordinates
+        ; caused by the user having dragged the mouse:</em>
+        CoordMode "Mouse"
+        MouseGetPos EWD_MouseX, EWD_MouseY
+        WinGetPos EWD_WinX, EWD_WinY,,, "ahk_id " EWD_MouseWin
+        SetWinDelay -1   <em>; Makes the below move faster/smoother.</em>
+        WinMove EWD_WinX + EWD_MouseX - EWD_MouseStartX, EWD_WinY + EWD_MouseY - EWD_MouseStartY,,, "ahk_id " EWD_MouseWin
+        EWD_MouseStartX := EWD_MouseX  <em>; Update for the next timer-call to this subroutine.</em>
+        EWD_MouseStartY := EWD_MouseY
+    }
 }
-if GetKeyState("Escape", "P")  <em>; Escape has been pressed, so drag is cancelled.</em>
-{
-    SetTimer , "Off"
-    WinMove EWD_OriginalPosX, EWD_OriginalPosY,,, "ahk_id " EWD_MouseWin
-    return
-}
-<em>; Otherwise, reposition the window to match the change in mouse coordinates
-; caused by the user having dragged the mouse:</em>
-CoordMode "Mouse"
-MouseGetPos EWD_MouseX, EWD_MouseY
-WinGetPos EWD_WinX, EWD_WinY,,, "ahk_id " EWD_MouseWin
-SetWinDelay -1   <em>; Makes the below move faster/smoother.</em>
-WinMove EWD_WinX + EWD_MouseX - EWD_MouseStartX, EWD_WinY + EWD_MouseY - EWD_MouseStartY,,, "ahk_id " EWD_MouseWin
-EWD_MouseStartX := EWD_MouseX  <em>; Update for the next timer-call to this subroutine.</em>
-EWD_MouseStartY := EWD_MouseY
-return
 </pre>
 </body>
 </html>

--- a/docs/scripts/JoystickMouse.ahk
+++ b/docs/scripts/JoystickMouse.ahk
@@ -58,97 +58,105 @@ JoyInfo := GetKeyState(JoystickNumber "JoyInfo")
 if InStr(JoyInfo, "P")  ; Joystick has POV control, so use it as a mouse wheel.
     SetTimer "MouseWheel", WheelDelay
 
-return  ; End of auto-execute section.
-
-
-; The subroutines below do not use KeyWait because that would sometimes trap the
+; The functions below do not use KeyWait because that would sometimes trap the
 ; WatchJoystick quasi-thread beneath the wait-for-button-up thread, which would
 ; effectively prevent mouse-dragging with the joystick.
 
-ButtonLeft:
-SetMouseDelay -1  ; Makes movement smoother.
-MouseClick "Left",,, 1, 0, "D"  ; Hold down the left mouse button.
-SetTimer "WaitForLeftButtonUp", 10
-return
-
-ButtonRight:
-SetMouseDelay -1  ; Makes movement smoother.
-MouseClick "Right",,, 1, 0, "D"  ; Hold down the right mouse button.
-SetTimer "WaitForRightButtonUp", 10
-return
-
-ButtonMiddle:
-SetMouseDelay -1  ; Makes movement smoother.
-MouseClick "Middle",,, 1, 0, "D"  ; Hold down the right mouse button.
-SetTimer "WaitForMiddleButtonUp", 10
-return
-
-WaitForLeftButtonUp:
-if GetKeyState(JoystickPrefix . ButtonLeft)
-    return  ; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.
-SetTimer , "Off"
-SetMouseDelay -1  ; Makes movement smoother.
-MouseClick "Left",,, 1, 0, "U"  ; Release the mouse button.
-return
-
-WaitForRightButtonUp:
-if GetKeyState(JoystickPrefix . ButtonRight)
-    return  ; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.
-SetTimer , "Off"
-MouseClick "Right",,, 1, 0, "U"  ; Release the mouse button.
-return
-
-WaitForMiddleButtonUp:
-if GetKeyState(JoystickPrefix . ButtonMiddle)
-    return  ; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.
-SetTimer , "Off"
-MouseClick "Middle",,, 1, 0, "U"  ; Release the mouse button.
-return
-
-WatchJoystick:
-MouseNeedsToBeMoved := false  ; Set default.
-joyx := GetKeyState(JoystickNumber "JoyX")
-joyy := GetKeyState(JoystickNumber "JoyY")
-if joyx > JoyThresholdUpper
-{
-    MouseNeedsToBeMoved := true
-    DeltaX := Round(joyx - JoyThresholdUpper)
-}
-else if joyx < JoyThresholdLower
-{
-    MouseNeedsToBeMoved := true
-    DeltaX := Round(joyx - JoyThresholdLower)
-}
-else
-    DeltaX := 0
-if joyy > JoyThresholdUpper
-{
-    MouseNeedsToBeMoved := true
-    DeltaY := Round(joyy - JoyThresholdUpper)
-}
-else if joyy < JoyThresholdLower
-{
-    MouseNeedsToBeMoved := true
-    DeltaY := Round(joyy - JoyThresholdLower)
-}
-else
-    DeltaY := 0
-if MouseNeedsToBeMoved
+ButtonLeft()
 {
     SetMouseDelay -1  ; Makes movement smoother.
-    MouseMove DeltaX * JoyMultiplier, DeltaY * JoyMultiplier * YAxisMultiplier, 0, "R"
+    MouseClick "Left",,, 1, 0, "D"  ; Hold down the left mouse button.
+    SetTimer "WaitForLeftButtonUp", 10
+    
+    WaitForLeftButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  ; The button is still, down, so keep waiting.
+        ; Otherwise, the button has been released.
+        SetTimer , "Off"
+        SetMouseDelay -1  ; Makes movement smoother.
+        MouseClick "Left",,, 1, 0, "U"  ; Release the mouse button.
+    }
 }
-return
 
-MouseWheel:
-JoyPOV := GetKeyState(JoystickNumber "JoyPOV")
-if JoyPOV = -1  ; No angle.
-    return
-if (JoyPOV > 31500 or JoyPOV < 4500)  ; Forward
-    Send "{WheelUp}"
-else if JoyPOV >= 13500 and JoyPOV <= 22500  ; Back
-    Send "{WheelDown}"
-return
+ButtonRight()
+{
+    SetMouseDelay -1  ; Makes movement smoother.
+    MouseClick "Right",,, 1, 0, "D"  ; Hold down the right mouse button.
+    SetTimer "WaitForRightButtonUp", 10
+    
+    WaitForRightButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  ; The button is still, down, so keep waiting.
+        ; Otherwise, the button has been released.
+        SetTimer , "Off"
+        MouseClick "Right",,, 1, 0, "U"  ; Release the mouse button.
+    }
+}
+
+ButtonMiddle()
+{
+    SetMouseDelay -1  ; Makes movement smoother.
+    MouseClick "Middle",,, 1, 0, "D"  ; Hold down the right mouse button.
+    SetTimer "WaitForMiddleButtonUp", 10
+    
+    WaitForMiddleButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  ; The button is still, down, so keep waiting.
+        ; Otherwise, the button has been released.
+        SetTimer , "Off"
+        MouseClick "Middle",,, 1, 0, "U"  ; Release the mouse button.
+    }
+
+}
+
+WatchJoystick()
+{
+    global
+    MouseNeedsToBeMoved := false  ; Set default.
+    joyx := GetKeyState(JoystickNumber "JoyX")
+    joyy := GetKeyState(JoystickNumber "JoyY")
+    if joyx > JoyThresholdUpper
+    {
+        MouseNeedsToBeMoved := true
+        DeltaX := Round(joyx - JoyThresholdUpper)
+    }
+    else if joyx < JoyThresholdLower
+    {
+        MouseNeedsToBeMoved := true
+        DeltaX := Round(joyx - JoyThresholdLower)
+    }
+    else
+        DeltaX := 0
+    if joyy > JoyThresholdUpper
+    {
+        MouseNeedsToBeMoved := true
+        DeltaY := Round(joyy - JoyThresholdUpper)
+    }
+    else if joyy < JoyThresholdLower
+    {
+        MouseNeedsToBeMoved := true
+        DeltaY := Round(joyy - JoyThresholdLower)
+    }
+    else
+        DeltaY := 0
+    if MouseNeedsToBeMoved
+    {
+        SetMouseDelay -1  ; Makes movement smoother.
+        MouseMove DeltaX * JoyMultiplier, DeltaY * JoyMultiplier * YAxisMultiplier, 0, "R"
+    }
+}
+
+MouseWheel()
+{
+    global
+    JoyPOV := GetKeyState(JoystickNumber "JoyPOV")
+    if JoyPOV = -1  ; No angle.
+        return
+    if (JoyPOV > 31500 or JoyPOV < 4500)  ; Forward
+        Send "{WheelUp}"
+    else if JoyPOV >= 13500 and JoyPOV <= 22500  ; Back
+        Send "{WheelDown}"
+}

--- a/docs/scripts/JoystickMouse.htm
+++ b/docs/scripts/JoystickMouse.htm
@@ -71,100 +71,108 @@ JoyInfo := GetKeyState(JoystickNumber "JoyInfo")
 if InStr(JoyInfo, "P")  <em>; Joystick has POV control, so use it as a mouse wheel.</em>
     SetTimer "MouseWheel", WheelDelay
 
-return  <em>; End of auto-execute section.</em>
-
-
-<em>; The subroutines below do not use KeyWait because that would sometimes trap the
+<em>; The functions below do not use KeyWait because that would sometimes trap the
 ; WatchJoystick quasi-thread beneath the wait-for-button-up thread, which would
 ; effectively prevent mouse-dragging with the joystick.</em>
 
-ButtonLeft:
-SetMouseDelay -1  <em>; Makes movement smoother.</em>
-MouseClick "Left",,, 1, 0, "D"  <em>; Hold down the left mouse button.</em>
-SetTimer "WaitForLeftButtonUp", 10
-return
-
-ButtonRight:
-SetMouseDelay -1  <em>; Makes movement smoother.</em>
-MouseClick "Right",,, 1, 0, "D"  <em>; Hold down the right mouse button.</em>
-SetTimer "WaitForRightButtonUp", 10
-return
-
-ButtonMiddle:
-SetMouseDelay -1  <em>; Makes movement smoother.</em>
-MouseClick "Middle",,, 1, 0, "D"  <em>; Hold down the right mouse button.</em>
-SetTimer "WaitForMiddleButtonUp", 10
-return
-
-WaitForLeftButtonUp:
-if GetKeyState(JoystickPrefix . ButtonLeft)
-    return  <em>; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.</em>
-SetTimer , "Off"
-SetMouseDelay -1  <em>; Makes movement smoother.</em>
-MouseClick "Left",,, 1, 0, "U"  <em>; Release the mouse button.</em>
-return
-
-WaitForRightButtonUp:
-if GetKeyState(JoystickPrefix . ButtonRight)
-    return  <em>; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.</em>
-SetTimer , "Off"
-MouseClick "Right",,, 1, 0, "U"  <em>; Release the mouse button.</em>
-return
-
-WaitForMiddleButtonUp:
-if GetKeyState(JoystickPrefix . ButtonMiddle)
-    return  <em>; The button is still, down, so keep waiting.
-; Otherwise, the button has been released.</em>
-SetTimer , "Off"
-MouseClick "Middle",,, 1, 0, "U"  <em>; Release the mouse button.</em>
-return
-
-WatchJoystick:
-MouseNeedsToBeMoved := false  <em>; Set default.</em>
-joyx := GetKeyState(JoystickNumber "JoyX")
-joyy := GetKeyState(JoystickNumber "JoyY")
-if joyx > JoyThresholdUpper
-{
-    MouseNeedsToBeMoved := true
-    DeltaX := Round(joyx - JoyThresholdUpper)
-}
-else if joyx < JoyThresholdLower
-{
-    MouseNeedsToBeMoved := true
-    DeltaX := Round(joyx - JoyThresholdLower)
-}
-else
-    DeltaX := 0
-if joyy > JoyThresholdUpper
-{
-    MouseNeedsToBeMoved := true
-    DeltaY := Round(joyy - JoyThresholdUpper)
-}
-else if joyy < JoyThresholdLower
-{
-    MouseNeedsToBeMoved := true
-    DeltaY := Round(joyy - JoyThresholdLower)
-}
-else
-    DeltaY := 0
-if MouseNeedsToBeMoved
+ButtonLeft()
 {
     SetMouseDelay -1  <em>; Makes movement smoother.</em>
-    MouseMove DeltaX * JoyMultiplier, DeltaY * JoyMultiplier * YAxisMultiplier, 0, "R"
+    MouseClick "Left",,, 1, 0, "D"  <em>; Hold down the left mouse button.</em>
+    SetTimer "WaitForLeftButtonUp", 10
+    
+    WaitForLeftButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  <em>; The button is still, down, so keep waiting.</em>
+        ; Otherwise, the button has been released.
+        SetTimer , "Off"
+        SetMouseDelay -1  <em>; Makes movement smoother.</em>
+        MouseClick "Left",,, 1, 0, "U"  <em>; Release the mouse button.</em>
+    }
 }
-return
 
-MouseWheel:
-JoyPOV := GetKeyState(JoystickNumber "JoyPOV")
-if JoyPOV = -1  <em>; No angle.</em>
-    return
-if (JoyPOV > 31500 or JoyPOV < 4500)  <em>; Forward</em>
-    Send "{WheelUp}"
-else if JoyPOV &gt;= 13500 and JoyPOV &lt;= 22500  <em>; Back</em>
-    Send "{WheelDown}"
-return
+ButtonRight()
+{
+    SetMouseDelay -1  <em>; Makes movement smoother.</em>
+    MouseClick "Right",,, 1, 0, "D"  <em>; Hold down the right mouse button.</em>
+    SetTimer "WaitForRightButtonUp", 10
+    
+    WaitForRightButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  <em>; The button is still, down, so keep waiting.
+        ; Otherwise, the button has been released.</em>
+        SetTimer , "Off"
+        MouseClick "Right",,, 1, 0, "U"  <em>; Release the mouse button.</em>
+    }
+}
+
+ButtonMiddle()
+{
+    SetMouseDelay -1  <em>; Makes movement smoother.</em>
+    MouseClick "Middle",,, 1, 0, "D"  <em>; Hold down the right mouse button.</em>
+    SetTimer "WaitForMiddleButtonUp", 10
+    
+    WaitForMiddleButtonUp()
+    {
+        if GetKeyState(A_ThisHotkey)
+            return  <em>; The button is still, down, so keep waiting.
+        ; Otherwise, the button has been released.</em>
+        SetTimer , "Off"
+        MouseClick "Middle",,, 1, 0, "U"  <em>; Release the mouse button.</em>
+    }
+
+}
+
+WatchJoystick()
+{
+    global
+    MouseNeedsToBeMoved := false  <em>; Set default.</em>
+    joyx := GetKeyState(JoystickNumber "JoyX")
+    joyy := GetKeyState(JoystickNumber "JoyY")
+    if joyx > JoyThresholdUpper
+    {
+        MouseNeedsToBeMoved := true
+        DeltaX := Round(joyx - JoyThresholdUpper)
+    }
+    else if joyx < JoyThresholdLower
+    {
+        MouseNeedsToBeMoved := true
+        DeltaX := Round(joyx - JoyThresholdLower)
+    }
+    else
+        DeltaX := 0
+    if joyy > JoyThresholdUpper
+    {
+        MouseNeedsToBeMoved := true
+        DeltaY := Round(joyy - JoyThresholdUpper)
+    }
+    else if joyy < JoyThresholdLower
+    {
+        MouseNeedsToBeMoved := true
+        DeltaY := Round(joyy - JoyThresholdLower)
+    }
+    else
+        DeltaY := 0
+    if MouseNeedsToBeMoved
+    {
+        SetMouseDelay -1  <em>; Makes movement smoother.</em>
+        MouseMove DeltaX * JoyMultiplier, DeltaY * JoyMultiplier * YAxisMultiplier, 0, "R"
+    }
+}
+
+MouseWheel()
+{
+    global
+    JoyPOV := GetKeyState(JoystickNumber "JoyPOV")
+    if JoyPOV = -1  <em>; No angle.</em>
+        return
+    if (JoyPOV > 31500 or JoyPOV < 4500)  <em>; Forward</em>
+        Send "{WheelUp}"
+    else if JoyPOV >= 13500 and JoyPOV <= 22500  <em>; Back</em>
+        Send "{WheelDown}"
+}
 </pre>
 </body>
 </html>

--- a/docs/scripts/MsgBoxButtonNames.ahk
+++ b/docs/scripts/MsgBoxButtonNames.ahk
@@ -12,13 +12,13 @@ if Result = "Yes"
     MsgBox "You chose Add."
 else
     MsgBox "You chose Delete."
-return
 
-ChangeButtonNames:
-if !WinExist("Add or Delete")
-    return  ; Keep waiting.
-SetTimer , "Off"
-WinActivate
-ControlSetText "&Add", "Button1"
-ControlSetText "&Delete", "Button2"
-return
+ChangeButtonNames()
+{
+    if !WinExist("Add or Delete")
+        return  ; Keep waiting.
+    SetTimer , "Off"
+    WinActivate
+    ControlSetText "&Add", "Button1"
+    ControlSetText "&Delete", "Button2"
+}

--- a/docs/scripts/MsgBoxButtonNames.htm
+++ b/docs/scripts/MsgBoxButtonNames.htm
@@ -25,16 +25,16 @@ if Result = "Yes"
     MsgBox "You chose Add."
 else
     MsgBox "You chose Delete."
-return
 
-ChangeButtonNames:
-if !WinExist("Add or Delete")
-    return  <em>; Keep waiting.</em>
-SetTimer , "Off"
-WinActivate
-ControlSetText "&Add", "Button1"
-ControlSetText "&Delete", "Button2"
-return
+ChangeButtonNames()
+{
+    if !WinExist("Add or Delete")
+        return  <em>; Keep waiting.</em>
+    SetTimer , "Off"
+    WinActivate
+    ControlSetText "&Add", "Button1"
+    ControlSetText "&Delete", "Button2"
+}
 </pre>
 </body>
 </html>

--- a/docs/scripts/NumpadMouse.ahk
+++ b/docs/scripts/NumpadMouse.ahk
@@ -306,20 +306,22 @@ MouseClick ButtonClick,,, 1, 0, "D"
 SetTimer "ButtonClickEnd", 10
 return
 
-ButtonClickEnd:
-if GetKeyState(Button2, "P")
-    return
+ButtonClickEnd()
+{
+    global
+    if GetKeyState(Button2, "P")
+        return
 
-SetTimer , "Off"
-MouseClick ButtonClick,,, 1, 0, "U"
-return
+    SetTimer , "Off"
+    MouseClick ButtonClick,,, 1, 0, "U"
+}
 
 ;Mouse movement support
 
 ButtonSpeedUp:
 MouseSpeed++
 ToolTip "Mouse speed: " MouseSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonSpeedDown:
 if MouseSpeed > 1
@@ -328,12 +330,12 @@ if MouseSpeed = 1
     ToolTip "Mouse speed: " MouseSpeed " pixel"
 else
     ToolTip "Mouse speed: " MouseSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonAccelerationSpeedUp:
 MouseAccelerationSpeed++
 ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonAccelerationSpeedDown:
 if MouseAccelerationSpeed > 1
@@ -342,13 +344,13 @@ if MouseAccelerationSpeed = 1
     ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixel"
 else
     ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonMaxSpeedUp:
 MouseMaxSpeed++
 ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonMaxSpeedDown:
 if MouseMaxSpeed > 1
@@ -357,7 +359,7 @@ if MouseMaxSpeed = 1
     ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixel"
 else
     ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonRotationAngleUp:
@@ -367,7 +369,7 @@ if MouseRotationAnglePart >= 8
 MouseRotationAngle := MouseRotationAnglePart
 MouseRotationAngle *= 45
 ToolTip "Mouse rotation angle: " MouseRotationAngle "°"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonRotationAngleDown:
 MouseRotationAnglePart--
@@ -376,7 +378,7 @@ if MouseRotationAnglePart < 0
 MouseRotationAngle := MouseRotationAnglePart
 MouseRotationAngle *= 45
 ToolTip "Mouse rotation angle: " MouseRotationAngle "°"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonUp:
@@ -596,15 +598,20 @@ else if Button = "NumpadPgDn"
 SetTimer "ButtonAccelerationEnd", 10
 return
 
-ButtonAccelerationEnd:
-if GetKeyState(Button, "P")
-    Goto ButtonAccelerationStart
+ButtonAccelerationEnd()
+{
+    global
+    if GetKeyState(Button, "P")
+    {
+        Gosub ButtonAccelerationStart
+        return
+    }
 
-SetTimer , "Off"
-MouseCurrentAccelerationSpeed := 0
-MouseCurrentSpeed := MouseSpeed
-Button := 0
-return
+    SetTimer , "Off"
+    MouseCurrentAccelerationSpeed := 0
+    MouseCurrentSpeed := MouseSpeed
+    Button := 0
+}
 
 ;Mouse wheel movement support
 
@@ -616,7 +623,7 @@ if MouseWheelSpeedMultiplier <= 0
 MouseWheelSpeedReal := MouseWheelSpeed
 MouseWheelSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -632,7 +639,7 @@ if MouseWheelSpeedReal = 1
     ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " line"
 else
     ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelAccelerationSpeedUp:
@@ -643,7 +650,7 @@ if MouseWheelSpeedMultiplier <= 0
 MouseWheelAccelerationSpeedReal := MouseWheelAccelerationSpeed
 MouseWheelAccelerationSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelAccelerationSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -659,7 +666,7 @@ if MouseWheelAccelerationSpeedReal = 1
     ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " line"
 else
     ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelMaxSpeedUp:
@@ -670,7 +677,7 @@ if MouseWheelSpeedMultiplier <= 0
 MouseWheelMaxSpeedReal := MouseWheelMaxSpeed
 MouseWheelMaxSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelMaxSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -686,7 +693,7 @@ if MouseWheelMaxSpeedReal = 1
     ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " line"
 else
     ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelUp:
@@ -722,16 +729,16 @@ else if Button = "NumpadAdd"
 SetTimer "ButtonWheelAccelerationEnd", 100
 return
 
-ButtonWheelAccelerationEnd:
-if GetKeyState(Button, "P")
-    Goto ButtonWheelAccelerationStart
+ButtonWheelAccelerationEnd()
+{
+    global
+    if GetKeyState(Button, "P")
+    {
+        Gosub ButtonWheelAccelerationStart
+        return
+    }
 
-MouseWheelCurrentAccelerationSpeed := 0
-MouseWheelCurrentSpeed := MouseWheelSpeed
-Button := 0
-return
-
-RemoveToolTip:
-SetTimer , "Off"
-ToolTip
-return
+    MouseWheelCurrentAccelerationSpeed := 0
+    MouseWheelCurrentSpeed := MouseWheelSpeed
+    Button := 0
+}

--- a/docs/scripts/NumpadMouse.htm
+++ b/docs/scripts/NumpadMouse.htm
@@ -319,20 +319,22 @@ MouseClick ButtonClick,,, 1, 0, "D"
 SetTimer "ButtonClickEnd", 10
 return
 
-ButtonClickEnd:
-if GetKeyState(Button2, "P")
-    return
+ButtonClickEnd()
+{
+    global
+    if GetKeyState(Button2, "P")
+        return
 
-SetTimer , "Off"
-MouseClick ButtonClick,,, 1, 0, "U"
-return
+    SetTimer , "Off"
+    MouseClick ButtonClick,,, 1, 0, "U"
+}
 
 <em>;Mouse movement support</em>
 
 ButtonSpeedUp:
 MouseSpeed++
 ToolTip "Mouse speed: " MouseSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonSpeedDown:
 if MouseSpeed > 1
@@ -341,12 +343,12 @@ if MouseSpeed = 1
     ToolTip "Mouse speed: " MouseSpeed " pixel"
 else
     ToolTip "Mouse speed: " MouseSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonAccelerationSpeedUp:
 MouseAccelerationSpeed++
 ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonAccelerationSpeedDown:
 if MouseAccelerationSpeed > 1
@@ -355,13 +357,13 @@ if MouseAccelerationSpeed = 1
     ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixel"
 else
     ToolTip "Mouse acceleration speed: " MouseAccelerationSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonMaxSpeedUp:
 MouseMaxSpeed++
 ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonMaxSpeedDown:
 if MouseMaxSpeed > 1
@@ -370,7 +372,7 @@ if MouseMaxSpeed = 1
     ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixel"
 else
     ToolTip "Mouse maximum speed: " MouseMaxSpeed " pixels"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonRotationAngleUp:
@@ -380,7 +382,7 @@ if MouseRotationAnglePart &gt;= 8
 MouseRotationAngle := MouseRotationAnglePart
 MouseRotationAngle *= 45
 ToolTip "Mouse rotation angle: " MouseRotationAngle "&deg;"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonRotationAngleDown:
 MouseRotationAnglePart--
@@ -389,7 +391,7 @@ if MouseRotationAnglePart < 0
 MouseRotationAngle := MouseRotationAnglePart
 MouseRotationAngle *= 45
 ToolTip "Mouse rotation angle: " MouseRotationAngle "&deg;"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonUp:
@@ -609,15 +611,20 @@ else if Button = "NumpadPgDn"
 SetTimer "ButtonAccelerationEnd", 10
 return
 
-ButtonAccelerationEnd:
-if GetKeyState(Button, "P")
-    Goto ButtonAccelerationStart
+ButtonAccelerationEnd()
+{
+    global
+    if GetKeyState(Button, "P")
+    {
+        Gosub ButtonAccelerationStart
+        return
+    }
 
-SetTimer , "Off"
-MouseCurrentAccelerationSpeed := 0
-MouseCurrentSpeed := MouseSpeed
-Button := 0
-return
+    SetTimer , "Off"
+    MouseCurrentAccelerationSpeed := 0
+    MouseCurrentSpeed := MouseSpeed
+    Button := 0
+}
 
 <em>;Mouse wheel movement support</em>
 
@@ -629,7 +636,7 @@ if MouseWheelSpeedMultiplier &lt;= 0
 MouseWheelSpeedReal := MouseWheelSpeed
 MouseWheelSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -645,7 +652,7 @@ if MouseWheelSpeedReal = 1
     ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " line"
 else
     ToolTip "Mouse wheel speed: " MouseWheelSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelAccelerationSpeedUp:
@@ -656,7 +663,7 @@ if MouseWheelSpeedMultiplier &lt;= 0
 MouseWheelAccelerationSpeedReal := MouseWheelAccelerationSpeed
 MouseWheelAccelerationSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelAccelerationSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -672,7 +679,7 @@ if MouseWheelAccelerationSpeedReal = 1
     ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " line"
 else
     ToolTip "Mouse wheel acceleration speed: " MouseWheelAccelerationSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelMaxSpeedUp:
@@ -683,7 +690,7 @@ if MouseWheelSpeedMultiplier &lt;= 0
 MouseWheelMaxSpeedReal := MouseWheelMaxSpeed
 MouseWheelMaxSpeedReal *= MouseWheelSpeedMultiplier
 ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 ButtonWheelMaxSpeedDown:
 MouseWheelSpeedMultiplier := RegRead("HKCU\Control Panel\Desktop", "WheelScrollLines")
@@ -699,7 +706,7 @@ if MouseWheelMaxSpeedReal = 1
     ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " line"
 else
     ToolTip "Mouse wheel maximum speed: " MouseWheelMaxSpeedReal " lines"
-SetTimer "RemoveToolTip", 1000
+SetTimer () => ToolTip(), -1000
 return
 
 ButtonWheelUp:
@@ -735,19 +742,19 @@ else if Button = "NumpadAdd"
 SetTimer "ButtonWheelAccelerationEnd", 100
 return
 
-ButtonWheelAccelerationEnd:
-if GetKeyState(Button, "P")
-    Goto ButtonWheelAccelerationStart
+ButtonWheelAccelerationEnd()
+{
+    global
+    if GetKeyState(Button, "P")
+    {
+        Gosub ButtonWheelAccelerationStart
+        return
+    }
 
-MouseWheelCurrentAccelerationSpeed := 0
-MouseWheelCurrentSpeed := MouseWheelSpeed
-Button := 0
-return
-
-RemoveToolTip:
-SetTimer , "Off"
-ToolTip
-return
+    MouseWheelCurrentAccelerationSpeed := 0
+    MouseWheelCurrentSpeed := MouseWheelSpeed
+    Button := 0
+}
 </pre>
 </body>
 </html>

--- a/docs/scripts/WinLIRC.ahk
+++ b/docs/scripts/WinLIRC.ahk
@@ -243,7 +243,7 @@ ReceiveData(wParam, lParam)
                 else
                     RepeatCount := 1
                 ToolTip "Button from WinLIRC, " ButtonName " (" RepeatCount ")"
-                SetTimer "SplashOff", -3000  ; This allows more signals to be processed while displaying the window.
+                SetTimer () => ToolTip(), -3000  ; This allows more signals to be processed while displaying the window.
             }
             PrevButtonName := ButtonName
             PrevButtonTime := A_TickCount
@@ -251,12 +251,6 @@ ReceiveData(wParam, lParam)
     }
     return 1  ; Tell the program that no further processing of this message is needed.
 }
-
-
-
-SplashOff:
-ToolTip
-return
 
 
 

--- a/docs/scripts/WinLIRC.htm
+++ b/docs/scripts/WinLIRC.htm
@@ -257,7 +257,7 @@ ReceiveData(wParam, lParam)
                 else
                     RepeatCount := 1
                 ToolTip "Button from WinLIRC, " ButtonName " (" RepeatCount ")"
-                SetTimer "SplashOff", -3000  <em>; This allows more signals to be processed while displaying the window.</em>
+                SetTimer () => ToolTip(), -3000  <em>; This allows more signals to be processed while displaying the window.</em>
             }
             PrevButtonName := ButtonName
             PrevButtonTime := A_TickCount
@@ -265,12 +265,6 @@ ReceiveData(wParam, lParam)
     }
     return 1  <em>; Tell the program that no further processing of this message is needed.</em>
 }
-
-
-
-SplashOff:
-ToolTip
-return
 
 
 


### PR DESCRIPTION
Maybe a bug?

docs/commands/_If.htm, line 86:

```autohotkey
Hotkey "IfWinExist", "ahk_class Notepad"
Hotkey "#n", "Off"  ; Turn the hotkey off.
Hotkey 'If', 'WinExist("ahk_class Notepad")'
Hotkey "#n", "On"   ; Turn the same hotkey back on.

#if WinExist("ahk_class Notepad")
#n::WinActivate
```

Error message:
```
Error:  Parameter #2 must match an existing #If expression.

	Line#
	001: Hotkey("IfWinExist", "ahk_class Notepad")
	002: Hotkey("#n", "Off")
--->	003: Hotkey('If', 'WinExist("ahk_class Notepad")')
	004: Hotkey("#n", "On")
	007: Return
	007: WinActivate()
	007: Return
	008: Exit
	009: Exit
	009: Exit

The current thread will exit.
```

This also applies to example 1 + 4 starting from line 115.