### PR TITLE
v2: Variables and Expressions - Boolean AND/OR

### DIFF
--- a/docs/Variables.htm
+++ b/docs/Variables.htm
@@ -113,6 +113,8 @@ MsgBox(1.00)  <em>; Shows 1.0</em></pre>
       <p><strong>Unary minus (-)</strong>: Inverts the sign of its operand.</p>
       <p><strong>Unary plus (+)</strong>: <code>+N</code> is equivalent to <code>-(-N)</code>. This has no effect when applied to a pure number, but can be used to convert numeric strings to pure numbers.</p>
       <p><strong>Logical-not (!)</strong>: If the operand is blank or 0, the result of applying logical-not is 1, which means &quot;true&quot;. Otherwise, the result is 0 (false). For example: <code>!x or !(y and z)</code>. Note: The word NOT is synonymous with <strong>!</strong> except that <strong>!</strong> has a higher precedence. Consecutive unary operators such as <code><strong>!!</strong>Var</code> are allowed because they are evaluated in right-to-left order.</p>
+      <p id="pure-boolean">Use two consecutive <code>!!</code> (logical not) operators to perform type conversion into a <em>pure</em> boolean value. For example:
+      <pre>Obj := {}, MsgBox(<strong>!!</strong>Obj) <em>; Object(truthy) cast into a pure Boolean(1 or true)</em></pre></p>
       <p><strong>Bitwise-not (~)</strong>: This inverts each bit of its operand. If the operand is a floating point value, it is truncated to an integer prior to the calculation. As 64-bit signed integers are used, a positive input value will always give a negative result and vice versa. For example, <code>~0xf0f</code> evaluates to -0xf10 (-3856), which is binary equivalent to 0xfffffffffffff0f0. If an unsigned 32-bit value is intended, the result can be truncated with <code><i>result</i> &amp; 0xffffffff</code>.</p>
       <p id="amp"><strong>Address (&amp;)</strong>: <code>&amp;MyVar</code> retrieves the address of <em>MyVar</em>'s contents in memory, where <em>MyVar</em> is a user-created variable. <em>MyVar</em>'s contents can be a string, a 64-bit integer, a 64-bit floating-point number, or an object. This is typically used with <a href="commands/DllCall.htm#struct">DllCall structures</a>.</p>
       <p>The address operator can be used with other strings such as <code>&amp;"string"</code>, <code>&amp;(x . y)</code> or <code>&amp;A_LoopField</code>, with limitations:</p>
@@ -200,22 +202,34 @@ Var := "The color is " FoundColor    <em>; Auto-concat</em>
   </tr>
   <tr id="not">
     <td style="text-align:center"><strong>NOT</strong></td>
-    <td><strong>Logical-NOT</strong>. Except for its lower precedence, this is the same as the <strong>!</strong> operator. For example, <code>not (x = 3 or y = 3)</code> is the same as <code><strong>!</strong>(x = 3 or y = 3)</code>.</td>
+    <td><strong><p>Logical-NOT</strong>. Except for its lower precedence, this is the same as the <strong>!</strong> operator. For example, <code>not (x = 3 or y = 3)</code> is the same as <code><strong>!</strong>(x = 3 or y = 3)</code>.</p>
+    <p>Two consecutive <code>not not</code> (logical not) operators may be used to perform type conversion into <em>pure</em> boolean values, however, for such instances, the <a href="#pure-boolean">unary</a> version of the operator is recommended.</p></td>
   </tr>
-  <tr id="and">
-    <td style="text-align:center"><strong>AND<br>
-    &amp;&amp;</strong></td>
-    <td><p>Both of these are <strong>logical-AND</strong>. For example: <code>x &gt; 3 and x &lt; 10</code>.</p>
-      <p>In the expression <code>x and y</code>, if x is <a href="#Boolean">true</a>, the result is y. Otherwise the result is x, and y is not evaluated at all - <a href="Functions.htm#ShortCircuit">short-circuit evaluation</a> is applied to enhance performance. Although the result is not limited to boolean 0 and 1, it can be interpreted as a <a href="#Boolean">boolean</a> value as with any other expression. In effect, the result is true only if both inputs are true.</p>
-      <p>A line that begins with AND/OR/&amp;&amp;/|| (or any other operator) is automatically <a href="Scripts.htm#continuation">appended to</a> the line above it.</p>
-      </td>
-  </tr>
-  <tr id="or">
-    <td style="text-align:center"><strong>OR<br>
-    ||</strong></td>
-    <td><p>Both of these are <strong>logical-OR</strong>. For example: <code>x &lt;= 3 or x &gt;= 10</code>.</p>
-      <p>In the expression <em>x or y</em>, if x is <a href="#Boolean">false</a>, the result is y. Otherwise the result is x, and y is not evaluated at all - <a href="Functions.htm#ShortCircuit">short-circuit evaluation</a> is applied to enhance performance. Although the result is not limited to boolean 0 and 1, it can be interpreted as a <a href="#Boolean">boolean</a> value as with any other expression. In effect, the result is true if either input is true.</p></td>
-  </tr>
+    <tr id="and">
+      <td style="text-align:center"><strong>AND<br>
+      &amp;&amp;</strong></td>
+      <td><p>Both of these are <strong>logical-AND</strong>. For example: <code>x &gt; 3 and x &lt; 10</code>.</p>
+        <p>In an expression where <strong>all</strong> operands resolve to <em>True</em>, the <strong>last</strong> operand that resolved to <em>True</em> is returned. Otherwise, the <strong>first</strong> operand that resolves to <em>False</em> is returned. Effectively, only when all operands are true, will the result be true. Boolean expressions are subject to <a href="Functions.htm#ShortCircuit">short-circuit evaluation</a> (left to right) in order to enhance performance.
+        <pre>A := 1, B := {}, C := 20, D := True, E := "String" <em>; <strong>All</strong> operands are truthy and will be evaluated</em>
+MsgBox(A &amp;&amp; B &amp;&amp; C &amp;&amp; D &amp;&amp; E) <em>; The <strong>last</strong> truthy operand is returned ("String")</em></pre>
+        <pre>A := 1, B := "", C := 0, D := False, E := "String" <em>; B is falsey, C and D are false</em>
+MsgBox(A &amp;&amp; B &amp;&amp; ++C &amp;&amp; D &amp;&amp; E) <em>; The <strong>first</strong> falsey operand is returned (""). C, D and E are not evaluated and C is never incremented</em></pre>
+        <p>Since the result of an expression may be <a href="#Boolean">truthy or falsey</a>, in instances, where <em>pure</em> boolean values are required, the result can be <a href="#pure-boolean">typecast</a>.</p>
+        <p>A line that begins with <code>AND</code> or <code>&amp;&amp;</code> (or any other operator) is automatically <a href="Scripts.htm#continuation">appended to</a> the line above it.</p></td>
+        </td>
+    </tr>
+    <tr id="or">
+      <td style="text-align:center"><strong>OR<br>
+      ||</strong></td>
+      <td><p>Both of these are <strong>logical-OR</strong>. For example: <code>x &lt;= 3 or x &gt;= 10</code>.</p>
+        <p>In an expression where <strong>at least</strong> one operand resolves to <em>True</em>, the <strong>last</strong> operand that resolved to <em>True</em> is returned. Otherwise, the <strong>last</strong> operand that resolves to <em>False</em> is returned. Effectively, provided at least one operand is true, the result will be true. Boolean expressions are subject to <a href="Functions.htm#ShortCircuit">short-circuit evaluation</a> (left to right) in order to enhance performance.
+        <pre>A := "", B := False, C := 0, D := "String", E := 20 <em>; <strong>At least</strong> one operand is truthy. All operands up until D (including) will be evaluated</em>
+MsgBox(A || B || C || D || ++E) <em>; The <strong>first</strong> truthy operand is returned ("String"). E is not evaluated and is never incremented</em></pre>
+        <pre>A := "", B := False, C := 0 <em>; <strong>All</strong> operands are falsey and will be evaluated</em>
+MsgBox(A || B || C) <em>; The <strong>last</strong> falsey operand is returned (0)</em></pre>
+        <p>Since the result of an expression may be <a href="#Boolean">truthy or falsey</a>, in instances, where <em>pure</em> boolean values are required, the result can be <a href="#pure-boolean">typecast</a>.</p>
+        <p>A line that begins with <code>OR</code> or <code>||</code> (or any other operator) is automatically <a href="Scripts.htm#continuation">appended to</a> the line above it.</p></td>
+    </tr>
   <tr id="ternary">
     <td style="text-align:center"><strong>?:</strong></td>
     <td><p><strong>Ternary operator</strong>. This operator is a shorthand replacement for the <a href="commands/IfExpression.htm">if-else statement</a>. It evaluates the condition on its left side to determine which of its two branches should become its final result. For example, <code>var := x&gt;y ? 2 : 3</code> stores 2 in <em>Var</em> if x is greater than y; otherwise it stores 3. To enhance performance, only the winning branch is evaluated (see <a href="Functions.htm#ShortCircuit">short-circuit evaluation</a>).</p></td>
@@ -256,7 +270,7 @@ sumfn := Func("Sum")</pre>
       <p>Variable references in <em>expr</em> are resolved in the same way as in the equivalent full function definition. For instance, <em>expr</em> may refer to an outer function's local variables (as in any <a href="Functions.htm#nested">nested function</a>), in which case a new <a href="Functions.htm#closures">closure</a> is created and returned each time the fat arrow expression is evaluated. The function is <a href="Functions.htm#AssumeLocal">assume-local</a> if it is nested inside another function, otherwise it is <a href="Functions.htm#AssumeGlobal">assume-global</a>.</p>
       <p>Specifying a name for the function allows it to be called recursively or by other nested functions without storing a reference to the <a href="Functions.htm#closures">closure</a> within itself (thereby creating a problematic <a href="Objects.htm#Circular_References">circular reference</a>). It can also be helpful for debugging, such with <a href="objects/Func.htm#Name">Func.Name</a> or when displayed on the debugger's call stack.</p>
     </td>
-    
+
   </tr>
   <tr id="comma">
     <td style="text-align:center"><strong>,</strong></td>

--- a/docs/Variables.htm
+++ b/docs/Variables.htm
@@ -113,8 +113,6 @@ MsgBox(1.00)  <em>; Shows 1.0</em></pre>
       <p><strong>Unary minus (-)</strong>: Inverts the sign of its operand.</p>
       <p><strong>Unary plus (+)</strong>: <code>+N</code> is equivalent to <code>-(-N)</code>. This has no effect when applied to a pure number, but can be used to convert numeric strings to pure numbers.</p>
       <p><strong>Logical-not (!)</strong>: If the operand is blank or 0, the result of applying logical-not is 1, which means &quot;true&quot;. Otherwise, the result is 0 (false). For example: <code>!x or !(y and z)</code>. Note: The word NOT is synonymous with <strong>!</strong> except that <strong>!</strong> has a higher precedence. Consecutive unary operators such as <code><strong>!!</strong>Var</code> are allowed because they are evaluated in right-to-left order.</p>
-      <p id="pure-boolean">Use two consecutive <code>!!</code> (logical not) operators to perform type conversion into a <em>pure</em> boolean value. For example:
-      <pre>Obj := {}, MsgBox(<strong>!!</strong>Obj) <em>; Object(truthy) cast into a pure Boolean(1 or true)</em></pre></p>
       <p><strong>Bitwise-not (~)</strong>: This inverts each bit of its operand. If the operand is a floating point value, it is truncated to an integer prior to the calculation. As 64-bit signed integers are used, a positive input value will always give a negative result and vice versa. For example, <code>~0xf0f</code> evaluates to -0xf10 (-3856), which is binary equivalent to 0xfffffffffffff0f0. If an unsigned 32-bit value is intended, the result can be truncated with <code><i>result</i> &amp; 0xffffffff</code>.</p>
       <p id="amp"><strong>Address (&amp;)</strong>: <code>&amp;MyVar</code> retrieves the address of <em>MyVar</em>'s contents in memory, where <em>MyVar</em> is a user-created variable. <em>MyVar</em>'s contents can be a string, a 64-bit integer, a 64-bit floating-point number, or an object. This is typically used with <a href="commands/DllCall.htm#struct">DllCall structures</a>.</p>
       <p>The address operator can be used with other strings such as <code>&amp;"string"</code>, <code>&amp;(x . y)</code> or <code>&amp;A_LoopField</code>, with limitations:</p>
@@ -203,7 +201,6 @@ Var := "The color is " FoundColor    <em>; Auto-concat</em>
   <tr id="not">
     <td style="text-align:center"><strong>NOT</strong></td>
     <td><strong><p>Logical-NOT</strong>. Except for its lower precedence, this is the same as the <strong>!</strong> operator. For example, <code>not (x = 3 or y = 3)</code> is the same as <code><strong>!</strong>(x = 3 or y = 3)</code>.</p>
-    <p>Two consecutive <code>not not</code> (logical not) operators may be used to perform type conversion into <em>pure</em> boolean values, however, for such instances, the <a href="#pure-boolean">unary</a> version of the operator is recommended.</p></td>
   </tr>
     <tr id="and">
       <td style="text-align:center"><strong>AND<br>
@@ -214,7 +211,6 @@ Var := "The color is " FoundColor    <em>; Auto-concat</em>
 MsgBox(A &amp;&amp; B &amp;&amp; C &amp;&amp; D &amp;&amp; E) <em>; The <strong>last</strong> truthy operand is returned ("String")</em></pre>
         <pre>A := 1, B := "", C := 0, D := False, E := "String" <em>; B is falsey, C and D are false</em>
 MsgBox(A &amp;&amp; B &amp;&amp; ++C &amp;&amp; D &amp;&amp; E) <em>; The <strong>first</strong> falsey operand is returned (""). C, D and E are not evaluated and C is never incremented</em></pre>
-        <p>Since the result of an expression may be <a href="#Boolean">truthy or falsey</a>, in instances, where <em>pure</em> boolean values are required, the result can be <a href="#pure-boolean">typecast</a>.</p>
         <p>A line that begins with <code>AND</code> or <code>&amp;&amp;</code> (or any other operator) is automatically <a href="Scripts.htm#continuation">appended to</a> the line above it.</p></td>
         </td>
     </tr>
@@ -227,7 +223,6 @@ MsgBox(A &amp;&amp; B &amp;&amp; ++C &amp;&amp; D &amp;&amp; E) <em>; The <stron
 MsgBox(A || B || C || D || ++E) <em>; The <strong>first</strong> truthy operand is returned ("String"). E is not evaluated and is never incremented</em></pre>
         <pre>A := "", B := False, C := 0 <em>; <strong>All</strong> operands are falsey and will be evaluated</em>
 MsgBox(A || B || C) <em>; The <strong>last</strong> falsey operand is returned (0)</em></pre>
-        <p>Since the result of an expression may be <a href="#Boolean">truthy or falsey</a>, in instances, where <em>pure</em> boolean values are required, the result can be <a href="#pure-boolean">typecast</a>.</p>
         <p>A line that begins with <code>OR</code> or <code>||</code> (or any other operator) is automatically <a href="Scripts.htm#continuation">appended to</a> the line above it.</p></td>
     </tr>
   <tr id="ternary">


### PR DESCRIPTION
I was looking at something tucked away in [v2 Changes](https://autohotkey.com/v2/v2-changes.htm):

> The operators &&, ||, and and or yield whichever value determined the result, similar to JavaScript and Lua. For example, "" or "default" yields "default" instead of 1. Scripts which require a pure boolean value (0 or 1) can use something like !!(x or y) or (x or y) ? 1 : 0.

This behaviour is different to that observed in v1 and isn't necessarily apparent at a glance. I figured it would be a good idea to expand upon it in a place that likely gets more traffic. I added a couple of examples illustrating the usage as well as the type coercion technique.