### PR TITLE
Update ToolTip example section.htm

### DIFF
--- a/docs/commands/ToolTip.htm
+++ b/docs/commands/ToolTip.htm
@@ -46,11 +46,10 @@
 ; without having to use Sleep (which stops the current thread):</em>
 #Persistent
 ToolTip, Timed ToolTip`nThis will be displayed for 5 seconds.
-SetTimer, RemoveToolTip, 5000
+SetTimer, RemoveToolTip, -5000
 return
 
 RemoveToolTip:
-SetTimer, RemoveToolTip, Off
 ToolTip
 return</pre>
 


### PR DESCRIPTION
removed:
    SetTimer, RemoveToolTip, Off

from just below line 52 because if you merely change the number 5000 on line 49 to -5000 it does exactly the same thing. Why doesn't tooltip just have a timer param added to it?