### PR TITLE
Replacing <> with !=

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -249,7 +249,7 @@ static TotalAttempts := 0, PrevResult</pre>
 <p>Finally, a dynamic call to a function is slightly slower than a normal call because normal calls are resolved (looked up) before the script begins running.</p>
 <h2 id="ShortCircuit">Short-circuit Boolean Evaluation</h2>
 <p>When <em>AND, OR</em>, and the <a href="Variables.htm#ternary">ternary operator</a> are used within an <a href="Variables.htm#Expressions">expression</a>, they short-circuit to enhance performance (regardless of whether any function calls are present). Short-circuiting operates by refusing to evaluate parts of an expression that cannot possibly affect its final result. To illustrate the concept, consider this example:</p>
-<pre>if (ColorName &lt;&gt; &quot;&quot; AND not FindColor(ColorName))
+<pre>if (ColorName != &quot;&quot; AND not FindColor(ColorName))
     MsgBox ColorName " could not be found."</pre>
 <p>In the example above, the FindColor() function never gets called if the <em>ColorName</em> variable is empty. This is because the left side of the <em>AND</em> would be <em>false</em>, and thus its right side would be incapable of making the final outcome <em>true</em>.</p>
 <p>Because of this behavior, it's important to realize that any side-effects produced by a function (such as altering a global variable's contents) might never occur if that function is called on the right side of an <em>AND</em> or <em>OR</em>.</p>

--- a/docs/Objects.htm
+++ b/docs/Objects.htm
@@ -138,7 +138,7 @@ x := "", y := ""             <em>; Without the above line, this would not free t
 <p>All types of objects support both array syntax (brackets) and object syntax (dots).</p>
 <p>Additionally, object references can themselves be used in expressions:</p>
 <ul>
-  <li>When an object reference is compared with some other value using one of <code>= == != &lt;&gt;</code>, they are considered equal only if both values are references to the same object.</li>
+  <li>When an object reference is compared with some other value using one of <code>= == != !==</code>, they are considered equal only if both values are references to the same object.</li>
   <li>Objects are always considered <i>true</i> when a boolean value is required, such as in <code>if obj</code>, <code>!obj</code> or <code>obj ? x : y</code>.</li>
   <li>An object's address can be retrieved using the <code>&amp;</code>address-of operator. This uniquely identifies the object from the point of its creation to the moment its last reference is <a href="#Refs">released</a>.</li>
 </ul>

--- a/docs/Variables.htm
+++ b/docs/Variables.htm
@@ -43,12 +43,12 @@ MsgBox Format("Var has the value {1}.", Var)
 <p class="note">See <a href="Language.htm#expressions">Expressions</a> for a structured overview and further explanation.</p>
 <p>Expressions are used to perform one or more operations upon a series of variables, literal strings, and/or literal numbers.</p>
 <p>Plain words in expressions are interpreted as variable names. Consequently, literal strings must be enclosed in double quotes to distinguish them from variables. For example:</p>
-<pre>if (CurrentSetting &gt; 100 or FoundColor &lt;&gt; &quot;Blue&quot;)
+<pre>if (CurrentSetting &gt; 100 or FoundColor != &quot;Blue&quot;)
     MsgBox "The setting is too high or the wrong color is present."</pre>
 <p>In the example above, &quot;Blue&quot; appears in quotes because it is a literal string. Single-quote marks (&apos;) and double-quote marks (&quot;) function identically, except that a string enclosed in single-quote marks can contain literal double-quote marks and vice versa. Therefore, to include an <em>actual</em> quote mark inside a literal string, <a href="misc/EscapeChar.htm">escape</a> the quote mark or enclose the string in the opposite type of quote mark. For example:</p>
 <pre>MsgBox &quot;She said, <span class="red">`&quot;</span>An apple a day.<span class="red">`&quot;</span>&quot;
 MsgBox <span class="red">&apos;</span>She said, &quot;An apple a day.&quot;<span class="red">&apos;</span></pre>
-<p><strong>Empty strings</strong>: To specify an empty string in an expression, use an empty pair of quotes. For example, the statement <code>if (MyVar &lt;&gt; &quot;&quot;)</code> would be true if <em>MyVar</em> is not blank.</p>
+<p><strong>Empty strings</strong>: To specify an empty string in an expression, use an empty pair of quotes. For example, the statement <code>if (MyVar != &quot;&quot;)</code> would be true if <em>MyVar</em> is not blank.</p>
 <p><strong>Storing the result of an expression</strong>: To assign a result to a variable, use the <a href="commands/SetExpression.htm">:= operator</a>. For example:</p>
 <pre>NetPrice := Price * (1 - Discount/100)</pre>
 <p id="Boolean"><strong>Boolean values</strong>: When an expression is required to evaluate to true or false (such as an IF-statement), a blank or zero result is considered false and all other results are considered true. For example, the statement <code>if ItemCount</code> would be false only if ItemCount is blank or 0. Similarly, the expression <code>if not ItemCount</code> would yield the opposite result.</p>

--- a/docs/commands/DriveEject.htm
+++ b/docs/commands/DriveEject.htm
@@ -63,7 +63,7 @@ hVolume := DllCall("CreateFile"
     , UInt, 0
     , UInt, 0x3  <em>; OPEN_EXISTING</em>
     , UInt, 0, UInt, 0)
-if (hVolume &lt;&gt; -1)
+if (hVolume != -1)
 {
     DllCall("DeviceIoControl"
         , UInt, hVolume

--- a/docs/commands/FileCopy.htm
+++ b/docs/commands/FileCopy.htm
@@ -52,7 +52,7 @@ FileCopy "C:\My File.txt", "C:\My File New.txt"  <em>; Copy a file into the same
 FileCopy "C:\Folder1\*.txt", "D:\New Folder\*.bkp"  <em>; Copy to new location and give new extension.</em></pre>
 <pre class="NoIndent"><em>; The following example copies all files and folders inside a folder to a different folder:</em>
 ErrorCount := CopyFilesAndFolders(&quot;C:\My Folder\*.*&quot;, &quot;D:\Folder to receive all files &amp; folders&quot;)
-if ErrorCount &lt;&gt; 0
+if ErrorCount != 0
     MsgBox ErrorCount " files/folders could not be copied."
 
 CopyFilesAndFolders(SourcePattern, DestinationFolder, DoOverwrite := false)

--- a/docs/commands/FileMove.htm
+++ b/docs/commands/FileMove.htm
@@ -51,7 +51,7 @@ FileMove "C:\File Before.txt", "C:\File After.txt"  <em>; Rename a single file.<
 FileMove "C:\Folder1\*.txt", "D:\New Folder\*.bkp"  <em>; Move and rename files to a new extension.</em></pre>
 <pre class="NoIndent"><em>; The following example moves all files and folders inside a folder to a different folder:</em>
 ErrorCount := MoveFilesAndFolders(&quot;C:\My Folder\*.*&quot;, &quot;D:\Folder to receive all files &amp; folders&quot;)
-if ErrorCount &lt;&gt; 0
+if ErrorCount != 0
     MsgBox ErrorCount " files/folders could not be moved."
 
 MoveFilesAndFolders(SourcePattern, DestinationFolder, DoOverwrite := false)

--- a/docs/commands/KeyWait.htm
+++ b/docs/commands/KeyWait.htm
@@ -73,7 +73,7 @@ return</pre>
 ; Note: There is a more elaborate script to distinguish between single, double, and
 ; triple-presses at the bottom of the <a href="SetTimer.htm">SetTimer</a> page.</em>
 ~RControl::
-if (A_PriorHotkey &lt;&gt; &quot;~RControl&quot; or A_TimeSincePriorHotkey &gt; 400)
+if (A_PriorHotkey != &quot;~RControl&quot; or A_TimeSincePriorHotkey &gt; 400)
 {
     <em>; Too much time between presses, so this isn't a double-press.</em>
     KeyWait "RControl"

--- a/docs/objects/Gui.htm
+++ b/docs/objects/Gui.htm
@@ -527,7 +527,7 @@ WM_MOUSEMOVE(wParam, lParam, msg, Hwnd)
 {
     global  
     static PrevHwnd
-    if (Hwnd &lt;&gt; PrevHwnd)
+    if (Hwnd != PrevHwnd)
     {
         Text := "", <a href="../commands/ToolTip.htm">ToolTip</a>() <em>; Turn off any previous tooltip.</em>
         CurrControl := GuiCtrlFromHwnd(Hwnd)

--- a/docs/objects/Menu.htm
+++ b/docs/objects/Menu.htm
@@ -402,7 +402,7 @@ TestDeleteAll()
 TestRename()
 {
     static
-    if NewName &lt;&gt; "renamed"
+    if NewName != "renamed"
     {
         OldName := "TestRename"
         NewName := "renamed"

--- a/docs/scripts/FavoriteFolders.htm
+++ b/docs/scripts/FavoriteFolders.htm
@@ -80,7 +80,7 @@ f_Paths := []
 f_Menu := MenuCreate()
 Loop Read, f_FavoritesFile
 {
-    if f_FileExt &lt;&gt; "Exe"
+    if f_FileExt != "Exe"
     {
         <em>; Since the menu items are being read directly from this
         ; script, skip over all lines until the starting line is

--- a/docs/scripts/IntelliSense.htm
+++ b/docs/scripts/IntelliSense.htm
@@ -44,11 +44,11 @@ I_Icon := ""
 SetKeyDelay 0
 #SingleInstance
 
-if I_HelpHotkey &lt;&gt; ""
+if I_HelpHotkey != ""
     Hotkey I_HelpHotkey, "I_HelpHotkey"
 
 <em>; Change tray icon (if one was specified in the configuration section above):</em>
-if I_Icon &lt;&gt; ""
+if I_Icon != ""
     if FileExist(I_Icon)
         TraySetIcon I_Icon
 

--- a/docs/scripts/MinimizeToTrayMenu.htm
+++ b/docs/scripts/MinimizeToTrayMenu.htm
@@ -246,7 +246,7 @@ mwt_RestoreAllThenExit()
 mwt_RestoreAll:
 Loop mwt_MaxWindows
 {
-    if mwt_WindowID%A_Index% &lt;&gt; ""
+    if mwt_WindowID%A_Index% != ""
     {
         IDToRestore := mwt_WindowID%A_Index%
         WinShow "ahk_id " IDToRestore

--- a/docs/scripts/NumpadMouse.htm
+++ b/docs/scripts/NumpadMouse.htm
@@ -403,7 +403,7 @@ ButtonUpLeft:
 ButtonUpRight:
 ButtonDownLeft:
 ButtonDownRight:
-if Button &lt;&gt; 0
+if Button != 0
 {
     if !InStr(A_ThisHotkey, Button)
     {
@@ -713,9 +713,9 @@ return
 ButtonWheelUp:
 ButtonWheelDown:
 
-if Button &lt;&gt; 0
+if Button != 0
 {
-    if Button &lt;&gt; A_ThisHotkey
+    if Button != A_ThisHotkey
     {
         MouseWheelCurrentAccelerationSpeed := 0
         MouseWheelCurrentSpeed := MouseWheelSpeed

--- a/docs/scripts/Seek_(SearchTheStartMenu).htm
+++ b/docs/scripts/Seek_(SearchTheStartMenu).htm
@@ -291,7 +291,7 @@ FindMatches(this)
             Line := A_LoopField
             if RegExMatch(Line, "%(L\d+)%", m) <em>; Replace %L_n% with location paths.</em>
                 Line := StrReplace(Line, "%" m[1] "%", %m[1]%)
-            if (SearchText &lt;&gt; E_Search.Value)
+            if (SearchText != E_Search.Value)
             {
                 <em>; User has changed the search string.
                 ; There is no point to continue searching using the old string, so abort.</em>
@@ -381,7 +381,7 @@ OpenFolder(this)
     <em>; If user selected a file-record instead of a directory-record, extract the
     ; directory path (I'm using DriveGetStatus instead of FileGetAttrib to allow the
     ; scenario whereby LB.Text is invalid but the directory path of LB.Text is valid):</em>
-    if (DriveGetStatus(Path) &lt;&gt; "Ready") <em>; not a directory</em>
+    if (DriveGetStatus(Path) != "Ready") <em>; not a directory</em>
     {
         SplitPath(Path,, Dir)
         Path := Dir

--- a/docs/scripts/WinLIRC.htm
+++ b/docs/scripts/WinLIRC.htm
@@ -227,7 +227,7 @@ ReceiveData(wParam, lParam)
         WinsockError := DllCall("Ws2_32\WSAGetLastError")
         if WinsockError = 10035  <em>; WSAEWOULDBLOCK, which means "no more data to be read".</em>
             return 1
-        if WinsockError &lt;&gt; 10054 <em>; WSAECONNRESET, which happens when WinLIRC closes via system shutdown/logoff.</em>
+        if WinsockError != 10054 <em>; WSAECONNRESET, which happens when WinLIRC closes via system shutdown/logoff.</em>
             <em>; Since it's an unexpected error, report it.  Also exit to avoid infinite loop.</em>
             MsgBox "recv() indicated Winsock error " WinsockError
         ExitApp  <em>; The OnExit routine will call WSACleanup() for us.</em>


### PR DESCRIPTION
Hello
Replacing removed operator `<>` with `!=`.
In `Objects.htm`, one `<>` was replaced by a `!==`.

Reason: `<>` was removed and `!==` was added.

I have not considered if any `!=` should be `!==`, this was just to remove all `<>`.

Cheers.