### PR TITLE
RegExMatchObjectExample: added example of regex starting with 'O)'

### DIFF
--- a/docs/commands/RegExMatch.htm
+++ b/docs/commands/RegExMatch.htm
@@ -91,7 +91,10 @@ FoundPos := RegExMatch(&quot;abc123&quot;, &quot;i)^ABC&quot;)  <em>; Returns 1 
 FoundPos := RegExMatch(&quot;abcXYZ123&quot;, &quot;abc(.*)123&quot;, SubPat)  <em>; Returns 1 and stores &quot;XYZ&quot; in SubPat1.</em>
 FoundPos := RegExMatch(&quot;abc123abc456&quot;, &quot;abc\d+&quot;, &quot;&quot;, 2)  <em>; Returns 7 instead of 1 due to StartingPosition 2 vs. 1.</em>
 
-<em>; For general RegEx examples, see the <a href="../misc/RegEx-QuickRef.htm">RegEx Quick Reference</a>.</em></pre>
+<em>; For general RegEx examples, see the <a href="../misc/RegEx-QuickRef.htm">RegEx Quick Reference</a>.</em>
+
+FoundPos := RegExMatch(&quot;Michiganroad 72&quot;, &quot;O)(.*) (?&lt;nr&gt;\d+)&quot;, SubPat)  <em>; The starting "O)" turns SubPat into an object.</em>
+Msgbox % SubPat.Count() ": " SubPat.Value(1) " " SubPat.Name(2) "=" SubPat["nr"]  <em>; Displays "2: Michiganroad nr=72"</em></pre>
 
 </body>
 </html>


### PR DESCRIPTION
and example how to access its group values

Old:
https://autohotkey.com/docs/commands/RegExMatch.htm#Examples

New:
![2018-12-27_0001](https://user-images.githubusercontent.com/2582910/50459346-8390d080-096a-11e9-8f76-aeab20c63633.png)

