### PR TITLE
v2: Remove spaces in ternaries warning

### DIFF
--- a/docs/Language.htm
+++ b/docs/Language.htm
@@ -78,7 +78,7 @@ Methods?
   <li><a href="Scripts.htm#continuation-expr">Continuation by enclosure</a>: A sub-expression enclosed in (), [] or {} can automatically span multiple lines in most cases.</li>
   <li><a href="Scripts.htm#continuation-section">Continuation section</a>: Multiple lines are merged with the line above the section, which starts with <code>(</code> and ends with <code>)</code> (both symbols must appear at the beginning of a line, excluding whitespace).</li>
 </ul>
- 
+
 
 <h2 id="comments">Comments</h2>
 <p><em>Comments</em> are portions of text within the script which are ignored by the program. They are typically used to add explanation or disable parts of the code.</p>
@@ -178,8 +178,7 @@ Run("notepad.exe", , , notepadPID)
 <p>Method calls such as <code>MyObj.MyMethod()</code>.</p>
 <p>Member access using square brackets, such as <code>MyObj[Index]</code>, which can have side-effects like a function call.</p>
 <p>Expressions starting with the <code>new</code> operator, as in <code>new ClassName</code>, because sometimes a class can be instantiated just for its side-effects.</p>
-<p>Ternary expressions such as <code>x? CallIfTrue() : CallIfFalse()</code>.</p>
-<p class="warning"><strong>Known limitation:</strong> There currently cannot be a space between the variable name and question mark.</p>
+<p><a href="Variables.htm#ternary">Ternary</a> expressions such as <code>x ? CallIfTrue() : CallIfFalse()</code>.</p>
 <p>Expressions starting with <code>(</code>. However, there usually must be a matching <code>)</code> on the same line, otherwise the line would be interpreted as the start of a <a href="Scripts.htm#continuation">continuation section</a>.</p>
 <p>Expressions starting with a double-deref, such as <code>%varname% := 1</code>. This is primarily due to implementation complexity.</p>
 <p>Expressions that start with any of those described above (but not those described below) are also allowed, for simplicity. For example, <code>MyFunc()+1</code> is currently allowed, although the <code>+1</code> has no effect and its result is discarded. Such expressions might become invalid in the future due to enhanced error-checking.</p>


### PR DESCRIPTION
Removed spaces in ternaries limitation warning and added a link to it. This was supposedly fixed in 2009.