### PR TITLE
Amend "conditional" #Include example

### DIFF
--- a/docs/commands/_Include.htm
+++ b/docs/commands/_Include.htm
@@ -42,10 +42,10 @@
 <p>The <em>FileName</em> parameter may optionally be preceded by <code>*i</code> and a single space, which causes the program to ignore any failure to read the included file. For example: <code>#Include *i SpecialOptions.ahk</code>. This option should be used only when the included file's contents are not essential to the main script's operation.</p>
 <p>Lines displayed in the main window via <a href="ListLines.htm">ListLines</a> or the menu View-&gt;Lines are always numbered according to their physical order within their own files. In other words, including a new file will change the line numbering of the main script file by only one line, namely that of the #Include line itself (except for <a href="../Scripts.htm#ahk2exe">compiled scripts</a>, which merge their included files into one big script at the time of compilation).</p>
 <p>#Include is often used to load <a href="../Functions.htm">functions</a> defined in an external file. Unlike subroutine labels, <a href="../Functions.htm">functions</a> can be included at the very top of the script without affecting the <a href="../Scripts.htm#auto">auto-execute section</a>.</p>
-<p>Like other # directives, #Include cannot be executed conditionally. In other words, this example would not work:</p>
+<p>Like other # directives, #Include cannot be executed conditionally:</p>
 <pre>if (x = 1)
-    #Include SomeFile.ahk  <em>; This line takes effect regardless of the value of x.</em>
-    y := 2  <em>; And this line would belong to the IF above, since # directives cannot belong to IFs.</em></pre>
+    #Include SomeFile.ahk  <em>; The contents of SomeFile.ahk will be inserted at this exact position, regardless of the value of x.</em>
+    y := 2  <em>; Depending on the contents of SomeFile.ahk, this line may or may not end up belonging to the if-statement above.</em></pre>
 <p>Files can be automatically included (i.e. without having to use #Include) by calling a <a href="../Functions.htm#lib">library function</a> by name.</p>
 
 <h2>Related</h2>


### PR DESCRIPTION
>  Like other # directives, #Include cannot be executed conditionally. In other words, **this example would not work**:
> 
> ```
> if (x = 1)
>     #Include SomeFile.ahk  ; This line takes effect regardless of the value of x.
>     y := 2  ; And **this line would belong to the IF above**, since # directives cannot belong to IFs.
> ```

1. The example wouldn't work only if the attempt to include `SomeFile.ahk` failed.
2. Cannot be asserted with certainty.