### PR TITLE
Adding documentation for #DllLoad

### DIFF
--- a/docs/commands/DllCall.htm
+++ b/docs/commands/DllCall.htm
@@ -153,7 +153,7 @@ DllCall(&quot;<strong>FreeLibrary</strong>&quot;, &quot;Ptr&quot;, hModule)  <em
 <strong>MulDivProc</strong> := DllCall(&quot;GetProcAddress&quot;, &quot;Ptr&quot;, DllCall(&quot;GetModuleHandle&quot;, &quot;Str&quot;, &quot;<strong>kernel32</strong>&quot;, &quot;Ptr&quot;), &quot;AStr&quot;, &quot;<strong>MulDiv</strong>&quot;, &quot;Ptr&quot;)
 Loop 500
     DllCall(<strong>MulDivProc</strong>, &quot;Int&quot;, 3, &quot;Int&quot;, 4, &quot;Int&quot;, 3)</pre>
-<p>If DllCall's first parameter is a literal string such as <code>"MulDiv"</code> and the DLL containing the function is ordinarily loaded before the script starts, the string is automatically resolved to a function address. This built-in optimization is more effective than the example shown above.</p>
+<p>If DllCall's first parameter is a literal string such as <code>"MulDiv"</code> and the DLL containing the function is ordinarily loaded before the script starts, or has been successfully loaded with <code>#DllLoad</code>, the string is automatically resolved to a function address. This built-in optimization is more effective than the example shown above.</p>
 <p>Finally, when passing a string-variable to a function that will not change the length of the string, performance is improved by passing the variable <a href="../Variables.htm#amp">by address</a> (e.g. &amp;MyVar) rather than as a &quot;<a href="#str">str</a>&quot; (especially when the string is very long). The following example converts a string to uppercase: <code>DllCall(&quot;CharUpper&quot;, &quot;<strong>Ptr</strong>&quot;, <strong>&amp;</strong>MyVar, &quot;Ptr&quot;)</code>.</p>
 
 <h2 id="struct">Structures and Arrays</h2>
@@ -179,7 +179,7 @@ result := DllCall(&quot;CharLower&quot;, &quot;<strong><u>Str</u></strong>&quot;
 </p>
 
 <h2>Related</h2>
-<p><a href="../Compat.htm#DllCall">Script Compatibility</a>, <a href="BufferAlloc.htm">BufferAlloc</a>, <a href="../objects/Buffer.htm">Buffer object</a>, <a href="PostMessage.htm">PostMessage</a>, <a href="OnMessage.htm">OnMessage</a>, <a href="CallbackCreate.htm">CallbackCreate</a>, <a href="Run.htm">Run</a>, <a href="VarSetCapacity.htm">VarSetCapacity</a>, <a href="../Functions.htm">Functions</a>, <a href="SysGet.htm">SysGet</a>, <a href="http://msdn.microsoft.com/library/">MSDN Library</a></p>
+<p><a href="../Compat.htm#DllCall">Script Compatibility</a>, <a href="BufferAlloc.htm">BufferAlloc</a>, <a href="../objects/Buffer.htm">Buffer object</a>, <a href="PostMessage.htm">PostMessage</a>, <a href="OnMessage.htm">OnMessage</a>, <a href="CallbackCreate.htm">CallbackCreate</a>, <a href="Run.htm">Run</a>, <a href="VarSetCapacity.htm">VarSetCapacity</a>, <a href="../Functions.htm">Functions</a>, <a href="SysGet.htm">SysGet</a>, <a href="http://msdn.microsoft.com/library/">MSDN Library</a>, <a href="_DllLoad.htm">#DllLoad</p>
 
 <h2>Examples</h2>
 <div class="ex" id="ExMessageBox">

--- a/docs/commands/_DllLoad.htm
+++ b/docs/commands/_DllLoad.htm
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<title>#DllLoad - Syntax &amp; Usage | AutoHotkey v2</title>
+<meta name="description" content="The #DllLoad directives are used to load DLL files before the script starts." />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<link href="../static/theme.css" rel="stylesheet" type="text/css" />
+<script src="../static/content.js" type="text/javascript"></script>
+</head>
+<body>
+
+<h1>#DllLoad</h1>
+
+<p><a href="DllCall.htm#load">Loads</a> a DLL or EXE file before the script starts executing.</p>
+
+<pre class="Syntax"><span class="func">#DllLoad</span> <span class="optional">FileOrDirName</span></pre>
+<h2>Parameters</h2>
+<dl>
+
+  <dt>FileOrDirName</dt>
+  <dd>
+    <p>Type: <a href="../Concepts.htm#strings">String</a></p>
+    <p>The path of a file or directory as explained below. This <strong>must not</strong> contain double quotes, wildcards or <a href="../misc/EscapeChar.htm">escape sequences</a> other than semicolon (<strong>`;</strong>).</p>
+    <p>Built-in variables may be used by enclosing them in percent signs (for example, <code>#DllLoad %A_ScriptDir%</code>). Percent signs which are not part of a valid variable reference are interpreted literally. All built-in variables are valid, except for <a href="../misc/ErrorLevel.htm">ErrorLevel</a> and <a href="../Variables.htm#Args">A_Args</a>.</p>
+    <p>Known limitation: When compiling a script, variables are evaluated by the compiler and may differ from what the script would return when it is finally executed. The following variables are supported: A_AhkPath, A_AppData, A_AppDataCommon, A_ComputerName, A_ComSpec, A_Desktop, A_DesktopCommon, A_IsCompiled, A_LineFile, A_MyDocuments, A_ProgramFiles, A_Programs, A_ProgramsCommon, A_ScriptDir, A_ScriptFullPath, A_ScriptName, A_Space, A_StartMenu, A_StartMenuCommon, A_Startup, A_StartupCommon, A_Tab, A_Temp, A_UserName, A_WinDir.</p>
+    <p><strong>File:</strong> The absolute or relative path to the DLL or EXE file to be loaded. If a relative path is specified, the directive searches for the file using the same search strategy as the system's function <a href="https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw">LoadLibraryW</a>. Note: <a href="SetWorkingDir.htm">SetWorkingDir</a> has no effect on #DllLoad because #DllLoad is processed before the script begins executing.</p>
+    <p><strong>Directory:</strong> Specify a directory instead of a file to alter the search strategy by all subsequent occurrences of #DllLoad which doesn't specify an aboslute path to a DLL or EXE. The new search strategy is the same as if <em>Directory</em> was passed to the system's function <a href="https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setdlldirectoryw">SetDllDirectoryW</a>. If this parameter is omitted, the default search strategy is restored.</p>
+  </dd>
+</dl>
+<h2>Remarks</h2>
+<p>Once a DLL or EXE has been loaded by this directive it cannot be unloaded by calling the system's function <a href="https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-freelibrary">FreeLibrary</a>. When the script is terminated, all loaded files are unloaded automatically.</p>
+<p>The <em>FileName</em> parameter may optionally be preceded by <code>*i</code> and a single space, which causes the program to ignore any failure to load the file. For example: <code>#DllLoad *i MyDLL</code>. This option should be used only when the DLL or EXE is not essential to the main script's operation.</p>
+<p>If the File parameter specifies a DLL name without a path and the file name extension is omitted, <em>.dll</em> is appended to the file name. To prevent this, include a trailing point character (.) in the file name.</p>
+<h2>Related</h2>
+<p><a href="DllCall.htm">DllCall</a></p>
+<h2>Examples</h2>
+<div class="ex" id="ExBasic">
+<p><a href="#ExBasic">#1</a></p>
+<pre>
+#DllLoad %A_MyDocuments%\MyDLL.dll
+</div>
+
+</body>
+</html>

--- a/docs/static/source/data_index.js
+++ b/docs/static/source/data_index.js
@@ -26,6 +26,7 @@ indexData = [
   ["&&","Variables.htm#and",4],
   ["&=","Variables.htm#AssignOp",4],
   ["#ClipboardTimeout","commands/_ClipboardTimeout.htm",0,"S"],
+  ["#DllLoad","commands/_DllLoad.htm",0,"S"],
   ["#ErrorStdOut","commands/_ErrorStdOut.htm",0,""],
   ["#HotkeyInterval","commands/_HotkeyInterval.htm",0,"S"],
   ["#HotkeyModifierTimeout","commands/_HotkeyModifierTimeout.htm",0,"S"],

--- a/docs/static/source/data_toc.js
+++ b/docs/static/source/data_toc.js
@@ -466,6 +466,7 @@ tocData = [
   ["#Directives","",
   [
     ["#ClipboardTimeout","commands/_ClipboardTimeout.htm"],
+	["#DllLoad","commands/_DllLoad.htm"],
     ["#ErrorStdOut","commands/_ErrorStdOut.htm"],
     ["#HotkeyInterval","commands/_HotkeyInterval.htm"],
     ["#HotkeyModifierTimeout","commands/_HotkeyModifierTimeout.htm"],


### PR DESCRIPTION
Due to [AutoHotkey_L/#136](https://github.com/Lexikos/AutoHotkey_L/pull/136).

Note: This documentation doesn't specify the current impact of `#DllLoad Directory` on `DllCall()`, which should be eliminated by [AutoHotkey_L/#151](https://github.com/Lexikos/AutoHotkey_L/pull/151).

OT: When compiling, there is a _Note:_ about an empty HTML tag in InputHook.htm.