### PR TITLE
Search: minor optimization and fix

### DIFF
--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -621,7 +621,8 @@ function ctor_search()
     // Get each word from index and clone for modification below:
     var all_results = []
     for (var i = 0; i < qry.length; ++i) {
-      var w = index_partial(qry[i])
+      var t = qry[i].replace(/(\(|\(\))$/,'') // special case for page names ending with ()
+      var w = index_partial(t)
       w = w ? w.slice() : []
       all_results[i] = get_results(w)
     }

--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -567,8 +567,8 @@ function ctor_search()
     SearchText = SearchText.toLowerCase().replace(/^ +| +$| +(?= )|\+/, '');
     if (SearchText == '')
       return '';
-    else
-      return SearchText.split(' ');
+    else // split and remove undefined or empty strings
+      return SearchText.split(' ').filter(function(e){return (!!e)});
   }
   self.highlightWords = function(words) {
     var content = $(isInsideFrame ? 'body' : '#right .area');


### PR DESCRIPTION
#### Commits Summary
- optimize search: don't process spaces strings as extra queries …
  > Minor improvement for when someone might type an extra white-space character by accident, it would cause the index search and ranking to happen per extra white-space character.

- fix search for function() page names …
  > Particularly terms like `Func()`, `isLabel()`, `InputHook()` would turn up with zero results because of the trailing `(` or `()`. The ranking will still take the trailing `()` into account, thus more accurate results for cases like these.