### PR TITLE
Search Input: mouse paste events are ignored

### DIFF
--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -521,8 +521,9 @@ function ctor_search()
     // --- Hook up events ---
 
     // Refresh the search list and show color indicator on input:
-    $searchInput.on('keyup input', function(e) {
+    $searchInput.on('input', function(e) {
       var $this = $(this);
+      var prevInput = cache.search_input; // defaults to undefined
       var input = cache.set('search_input', $this.val());
       // if no input, empty the search list, remove color indicator and return:
       if (!input) {
@@ -530,8 +531,8 @@ function ctor_search()
         $this.removeAttr('class');
         return;
       }
-      // Skip subsequent lines if no keyup event to prevent double execution:
-      if (e.type != "keyup")
+      // Skip subsequent search if we have the same query as the last search, to prevent double execution:
+      if (input == prevInput)
         return;
       // Otherwise fill the search list:
       cache.set('search_data', self.create(input));

--- a/docs/static/content.js
+++ b/docs/static/content.js
@@ -450,14 +450,15 @@ function ctor_index()
     // Select closest index entry and show color indicator on input:
     $indexInput.on('keyup input', function(e) {
       var $this = $(this);
+      var prevInput = cache.index_input; // defaults to undefined
       var input = cache.set('index_input', $this.val().toLowerCase());
       // if no input, remove color indicator and return:
       if (!input) {
         $this.removeAttr('class');
         return;
       }
-      // Skip subsequent lines if no keyup event to prevent double execution:
-      if (e.type != "keyup")
+      // Skip subsequent index-matching if we have the same query as the last search, to prevent double execution:
+      if (input == prevInput)
         return;
       // Otherwise find the first item which matches the input value:
       var indexListChildren = $indexList.children();
@@ -521,7 +522,7 @@ function ctor_search()
     // --- Hook up events ---
 
     // Refresh the search list and show color indicator on input:
-    $searchInput.on('input', function(e) {
+    $searchInput.on('keyup input', function(e) {
       var $this = $(this);
       var prevInput = cache.search_input; // defaults to undefined
       var input = cache.set('search_input', $this.val());


### PR DESCRIPTION
- Events like right-click cut or paste do not trigger the search until a key up event is triggered. This allows for partial cut and paste events to trigger the search.
- Search was triggered needlessly on left/right arrow keys
- Right-click cut clearing or browser-feature 'x' icon does not trigger search anyhow (before nor after this change)
- `oninput` event is sufficient, no need to handle `onkeyup` additionally
- Testing in IE v11.900.18362.0: any double execution seems to be prevented this way too, which seemed to be unique IE11 in my case anyhow.