### PR TITLE
Merge the two v1.1.33.00 changelogs together

### DIFF
--- a/docs/AHKL_ChangeLog.htm
+++ b/docs/AHKL_ChangeLog.htm
@@ -32,8 +32,6 @@
 <p>Fixed DBGp stderr copy mode to not suppress error dialogs.</p>
 <p>Fixed ControlGet Line setting ErrorLevel=1 when line is just empty.</p>
 <p>Fixed Send causing unwanted hotkey buffering.</p>
-
-<h2 id="v1.1.33.00">1.1.33.00 - June 15, 2020</h2>
 <p>Implemented numerous improvements to Ahk2Exe developed by fincs, TAC109, Joe DF, and Ben Allred.</p>
 <p>Added the capability to specify encoding with #ErrorStdOut or /ErrorStdOut=.</p>
 <p>Fixed some possible undefined behaviour in the Input command.</p>

--- a/docs/AHKL_ChangeLog.htm
+++ b/docs/AHKL_ChangeLog.htm
@@ -22,19 +22,9 @@
 <p>Added <a href="commands/_Warn.htm#Unreachable">#Warn Unreachable</a> (warning mode).</p>
 <p>Added <a href="commands/_Requires.htm">#Requires AutoHotkey v<em>Version</em></a> (directive).</p>
 <p>Added detection of program-terminating SEH exceptions, to display an error dialog.</p>
-<p>Fixed a possible bug where Input causes undefined behaviour. [PR #159 from Helgef] </p>
-<p>Fixed WinKill.</p>
-<p>Fixed A_WinDir to always return the system Windows directory.</p>
-<p>Fixed FileGetShortcut/FileCreateShortcut to return and accept negative icon indices without modification.</p>
-<p>Fixed InputBox Locale option to not focus the Cancel button.</p>
-<p>Fixed menu bar keyboard shortcuts not working when GUI has no controls.</p>
-<p>Fixed LoadPicture to use 256x256 graphic when available in a DLL/EXE.</p>
-<p>Fixed DBGp stderr copy mode to not suppress error dialogs.</p>
-<p>Fixed ControlGet Line setting ErrorLevel=1 when line is just empty.</p>
-<p>Fixed Send causing unwanted hotkey buffering.</p>
 <p>Implemented numerous improvements to Ahk2Exe developed by fincs, TAC109, Joe DF, and Ben Allred.</p>
-<p>Added the capability to specify encoding with #ErrorStdOut or /ErrorStdOut=.</p>
-<p>Fixed some possible undefined behaviour in the Input command.</p>
+<p>Fixed Send causing unwanted hotkey buffering.</p>
+<p>Fixed a possible bug where Input causes undefined behaviour. [PR #159 from Helgef] </p>
 <p>Fixed WinKill to actually do more than WinClose.</p>
 <p>Fixed A_WinDir to always return the system Windows directory.</p>
 <p>Fixed FileGetShortcut/FileCreateShortcut to not increment/decrement negative icon indices (resource IDs).</p>


### PR DESCRIPTION
Also, avoids any duplicate id. I'm guessing this was possibly updated by a script, if not and separate change logs with the same versioning are intentional, perhaps add a suffix to the IDs ?

Btw, glad this is finally released and all outstanding issues/PRs have been closed. So, sorry for this one... 