### PR TITLE
Fix use of <kbd> over colored backgrounds

### DIFF
--- a/docs/static/theme.css
+++ b/docs/static/theme.css
@@ -256,6 +256,7 @@ border:1px solid #ccc;
 border-radius:3px;
 box-shadow:0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px #fff inset;
 color:#333;
+background-color: #fff;
 display:inline-block;
 font-family:Consolas,Monaco,Courier New,monospace;
 line-height:1.4em;


### PR DESCRIPTION
For example, the "caution" text has the <kbd>Ctrl</kbd> and <kbd>Enter</kbd> over a yellow background. Key have no bgcolor specified so they end up being yellow on the inside too but unaffected on it's edges.
https://www.autohotkey.com/docs/Tutorial.htm#s3