### PR TITLE
Fix comment for #IfWinActive without parameters

### DIFF
--- a/docs/Tutorial.htm
+++ b/docs/Tutorial.htm
@@ -234,7 +234,7 @@ return</pre>
 MsgBox, You pressed ALT+Q in Notepad.
 return
 
-<em>; Any window that isn't Untitled - Notepad</em>
+<em>; Any window</em>
 #IfWinActive
 !q::
 MsgBox, You pressed ALT+Q in any window.


### PR DESCRIPTION
It says:
> To turn off context sensitivity for subsequent hotkeys or hotstrings, specify any #IfWin directive but leave all of its parameters blank.

But the comment next to ` #IfWinActive`  without parameters says:
```
; Any window that isn't Untitled - Notepad
```
It should be any window, including the "Untitled - Notepad" one

Fixing this comment.