### PR TITLE
fix typo in KeyList.htm

### DIFF
--- a/docs/KeyList.htm
+++ b/docs/KeyList.htm
@@ -164,7 +164,7 @@
   </tr>
 </table>
 <h3 id="numpad">Numpad Keys</h3>
-<p>Due to system behavior, the following keys seperated by a slash are identified differently depending on whether <kbd>NumLock</kbd> is ON or OFF. If <kbd>NumLock</kbd> is OFF but <kbd>Shift</kbd> is pressed, the system temporarily releases <kbd>Shift</kbd> and acts as though <kbd>NumLock</kbd> is ON.</p>
+<p>Due to system behavior, the following keys separated by a slash are identified differently depending on whether <kbd>NumLock</kbd> is ON or OFF. If <kbd>NumLock</kbd> is OFF but <kbd>Shift</kbd> is pressed, the system temporarily releases <kbd>Shift</kbd> and acts as though <kbd>NumLock</kbd> is ON.</p>
 <table class="info">
   <tr>
     <td style="width:12em">Numpad0 / NumpadIns</td><td><kbd>0</kbd> / <kbd>Insert</kbd></td>


### PR DESCRIPTION
"separated" is misspelled as "seperated".