### PR TITLE
Clarify what "AltGr" really means

### DIFF
--- a/docs/Hotkeys.htm
+++ b/docs/Hotkeys.htm
@@ -82,7 +82,7 @@ return</pre>
   </tr>
   <tr id="AltGr">
     <td><strong>&lt;^&gt;!</strong></td>
-    <td><p><kbd>AltGr</kbd> (alternate graving). If your keyboard layout has <kbd>AltGr</kbd> instead of a right <kbd>Alt</kbd> key, this series of symbols can usually be used to stand for <kbd>AltGr</kbd>. For example:</p>
+    <td><p><kbd>AltGr</kbd> <a href="https://en.wikipedia.org/wiki/AltGr_key">(alternate graph, or alternate graphic).</a> If your keyboard layout has <kbd>AltGr</kbd> instead of a right <kbd>Alt</kbd> key, this series of symbols can usually be used to stand for <kbd>AltGr</kbd>. For example:</p>
       <pre>&lt;^&gt;!m::MsgBox You pressed AltGr+m.
 &lt;^&lt;!m::MsgBox You pressed LeftControl+LeftAlt+m.</pre>
       <p>Alternatively, to make <kbd>AltGr</kbd> itself into a hotkey, use the following hotkey (without any hotkeys like the above present):</p>


### PR DESCRIPTION
"AltGr" reportedly stands for "alternate graving," which is wrong. Wikipedia shows it stands for "alternate graph," or "alternate graphic," as indicated by the Wikipedia reference.