### PR TITLE
Addition for when semicolon needs to be escaped

### DIFF
--- a/docs/misc/EscapeChar.htm
+++ b/docs/misc/EscapeChar.htm
@@ -26,7 +26,7 @@
   </tr>
   <tr>
     <td>`;</td>
-    <td>&nbsp;; (literal semicolon). <strong>Note:</strong> This is necessary <u>only</u> if a semicolon has a space or tab to its left, or when is the first character on a line when being remapped. If it does not, it will be recognized correctly without being escaped.</td>
+    <td>&nbsp;; (literal semicolon). <strong>Note:</strong> This is necessary <u>only</u> if a semicolon has a space or tab to its left, or when it is the first character on a line when being remapped. If it does not, it will be recognized correctly without being escaped.</td>
   </tr>
   <tr>
     <td>`:</td>

--- a/docs/misc/EscapeChar.htm
+++ b/docs/misc/EscapeChar.htm
@@ -26,7 +26,7 @@
   </tr>
   <tr>
     <td>`;</td>
-    <td>&nbsp;; (literal semicolon). <strong>Note:</strong> This is necessary <u>only</u> if a semicolon has a space or tab to its left. If it does not, it will be recognized correctly without being escaped.</td>
+    <td>&nbsp;; (literal semicolon). <strong>Note:</strong> This is necessary <u>only</u> if a semicolon has a space or tab to its left, or when is the first character on a line when being remapped. If it does not, it will be recognized correctly without being escaped.</td>
   </tr>
   <tr>
     <td>`:</td>


### PR DESCRIPTION
> [ Escaping a semicolon ] is necessary *only* if a semicolon has a space or tab to its left. If it does not, it will be recognized correctly without being escaped.

It is valid to remap the <kbd>;</kbd> key. However, to do so it must be escaped, otherwise the whole line will be seen as a comment.

This PR adds a line of text which mentions that a semicolon also needs to be escaped if it is being rebound.

```ahk
`;::x
`; & a::y
```

The sentence is a bit odd, but I also try to take into account that it does not need to be escaped if the rebind has a modifier

```ahk
!;::z ; does not need to be escaped
````