### PR TITLE
Fix for example #2

### DIFF
--- a/docs/commands/DllCall.htm
+++ b/docs/commands/DllCall.htm
@@ -171,7 +171,7 @@ MsgBox You pressed button #%WhichButton%.</pre>
 
 <div class="ex" id="ExWallpaper">
 <p><a href="#ExWallpaper">#2</a>: Changes the desktop wallpaper to the specified bitmap (.bmp) file.</p>
-<pre>DllCall("SystemParametersInfo", "UInt", 0x14, "UInt", 0, "Str", A_WinDir <strong>.</strong> "\winnt.bmp", "UInt", 2)</pre>
+<pre>DllCall("SystemParametersInfo", "UInt", 0x14, "UInt", 0, "Str", A_WinDir <strong>.</strong> "\winnt.bmp", "UInt", 1)</pre>
 </div>
 
 <div class="ex" id="ExIsWindowVisible">


### PR DESCRIPTION
This should fix an issue with the desktop background being reseted to the previous one after reboot. It was caused if the last value was set on "2" instead of "1".

Tested on Windows 10 Version 20H2 (Build 19042.804) with AHK 1.1.33.02 (64-bit).