### PR TITLE
Update RegEx-QuickRef.htm

### DIFF
--- a/docs/misc/RegEx-QuickRef.htm
+++ b/docs/misc/RegEx-QuickRef.htm
@@ -74,6 +74,10 @@
     <td class="center bold">P</td>
     <td>Position mode. This causes RegExMatch() to yield the position and length of the match and its subpatterns rather than their matching substrings. For details, see <a href="../commands/RegExMatch.htm#PosMode">OutputVar</a>.</td>
   </tr>
+  <tr id="opt_O">
+    <td class="center bold">O</td>
+    <td>Object mode. <span class="ver">[v1.1.05+]</span>: This causes RegExMatch() to yield all information of the match and its subpatterns to a <a href="../commands/RegExMatch.htm#MatchObject">match object</a> in OutputVar. For details, see <a href="../commands/RegExMatch.htm#ObjectMode">OutputVar</a>.</td>
+  </tr>
   <tr id="Study">
     <td class="center bold">S</td>
     <td>Studies the pattern to try improve its performance. This is useful when a particular pattern (especially a complex one) will be executed many times. If PCRE finds a way to improve performance, that discovery is stored alongside the pattern in the cache for use by subsequent executions of the same pattern (subsequent uses of that pattern should also specify the S option because finding a match in the cache requires that the option letters exactly match, including their order).</td>


### PR DESCRIPTION
Added `Object mode` for option `O)` that is missing from RegEx-QuickRef.