### PR TITLE
Add documentation of negitive number support

### DIFF
--- a/docs/commands/InStr.htm
+++ b/docs/commands/InStr.htm
@@ -33,7 +33,8 @@
       <p>Regardless of the value of <em>StartingPos</em>, the return value is always relative to the first character of <em>Haystack</em>. For example, the position of "abc" in "123abc789" is always 4.</p></dd>
 
   <dt>Occurrence <span class="ver">[AHK_L 57+]</span></dt>
-  <dd><p>If <em>Occurrence</em> is omitted, it defaults to the first match of the <em>Needle</em> in <em>Haystack</em>. Specify 2 for <em>Occurrence</em> to return the position of the second match, 3 for the third match, etc.</p></dd>
+  <dd><p>If <em>Occurrence</em> is omitted, it defaults to the first match of the <em>Needle</em> in <em>Haystack</em>. Specify 2 for <em>Occurrence</em> to return the position of the second match, 3 for the third match, etc.</p>
+  <p>If <em>Occurrence</em> is -1 it will return the position of the last match of <em>Needle</em> in <em>Haystack</em>. Similarly -2 will return the position of the second to last match, -3 for the third to last match, etc.</p></dd>
 
   </dl>
   
@@ -52,6 +53,11 @@
 <div class="ex" id="ExRetValue">
 <p><a class="ex_number" href="#ExRetValue"></a> Reports the 1-based position of the substring "abc" in the string "123abc789".</p>
 <pre>MsgBox % InStr("123abc789", "abc") <em>; Returns 4</em></pre>
+</div>
+
+<div class="ex" id="ExRetValueNeg">
+<p><a class="ex_number" href="#ExRetValueNeg"></a> Finds the position of the last occurance of "the" in the string "the cat in the hat"</p>
+<pre>MsgBox % InStr("the cat in the hat", "the",, -1) <em>; Returns 12</em></pre>
 </div>
 
 <div class="ex" id="ExBasic">


### PR DESCRIPTION
InStr() supports passing in a negative number for the parameter "occurrence" in order the find the nth occurrence from right to left instead of left to right. I believe that this is a very useful feature and should be mentioned in documentation.