### PR TITLE
Directories can be marked as read-only

### DIFF
--- a/docs/commands/DirExist.htm
+++ b/docs/commands/DirExist.htm
@@ -29,8 +29,9 @@
 
 <h2 id="Return_Value">Return Value</h2>
 <p>Type: <a href="../Concepts.htm#strings">String</a></p>
-<p>This function returns the attributes of the first matching folder. This string is a subset of <code>ASHDOC</code>, where each letter means the following:</p>
+<p>This function returns the attributes of the first matching folder. This string is a subset of <code>RASHDOC</code>, where each letter means the following:</p>
 <ul>
+    <li>R = READONLY</li>
     <li>A = ARCHIVE</li>
     <li>S = SYSTEM</li>
     <li>H = HIDDEN</li>


### PR DESCRIPTION
A directory can be marked as read-only. The common usage of marking a directory as read-only is to enable desktop.ini to specify a path to a .ico file. There is a choice of marking a directory as read only or system level hidden. 


Sample script:

    DirCreate "test"
    FileSetAttrib "+r", "test"
    MsgBox DirExist("test")

As you can see the directory has been marked read-only contary to what Windows says:

![a](https://user-images.githubusercontent.com/9779668/139960774-160ac5ff-0b2f-4ffb-bceb-07d0e0d59d10.png)
 