### PR TITLE
Added example number 3 (EnvGet)

### DIFF
--- a/docs/commands/EnvGet.htm
+++ b/docs/commands/EnvGet.htm
@@ -42,5 +42,11 @@
 MsgBox, Program files are in: %OutputVar%</pre>
 </div>
 
+<div class="ex" id="ExLocalAppData">
+<p><a class="ex_number" href="#ExLocalAppData"></a> Retrieves the path of the Local (AppData) directory from the current user.</p>
+<pre>EnvGet, LocalAppData, LocalAppData
+MsgBox, %A_UserName%'s Local directory is located at: %LocalAppData%</pre>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Retrieve LocalAppData path example added.

Edit: I did not mean to reference an old issue with the `#` character (my bad).