### PR TITLE
Added example number 2 (MaxMem directive)

### DIFF
--- a/docs/commands/_MaxMem.htm
+++ b/docs/commands/_MaxMem.htm
@@ -37,5 +37,10 @@
 <pre>#MaxMem 256</pre>
 </div>
 
+<div class="ex" id="ExMaxedMem">
+<p><a class="ex_number" href="#ExMaxedMem"></a> Allows the maximum amount of MB per variable.</p>
+<pre>#MaxMem 4095</pre>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
Maximum megabytes (4095MB) per variable example added.