### PR TITLE
Added Table Of Contents and Object Headers

### DIFF
--- a/docs/commands/InputHook.htm
+++ b/docs/commands/InputHook.htm
@@ -15,10 +15,59 @@
 <p>Creates an object which can be used to collect or intercept keyboard input.</p>
 
 <pre class="Syntax">InputHook := <span class="func">InputHook</span>(<span class="optional">Options, EndKeys, MatchList</span>)</pre>
+
+<h2 id="toc">Table of Contents</h2>
+<dl>
+<dd>
+  <ul>
+    <li><a href="#Parameters">Parameters</a></li>
+    <li><a href="#stack">Input Stack</a></li>
+    <li><a href="#object">InputHook Object</a></li>
+    <ul>
+      <li>
+      <a href="#InputHookObj_Methods"><u>Methods</u></a>
+      - <a href="#KeyOpt">KeyOpt</a>
+      , <a href="#Start">Start</a>
+      , <a href="#Wait">Wait</a>
+      , <a href="#Stop">Stop</a>
+      </li>
+      <li>
+      <a href="#InputHookObj_GeneralProperties"><u>General Properties</u></a>
+      - <a href="#EndKey">EndKey</a>
+      , <a href="#EndMods">EndMods</a>
+      , <a href="#EndReason">EndReason</a>
+      , <a href="#InProgress">InProgress</a>
+      , <a href="#Input">Input</a>
+      , <a href="#Match">Match</a>
+      , <a href="#OnEnd">OnEnd</a>
+      , <a href="#OnChar">OnChar</a>
+      , <a href="#OnKeyDown">OnKeyDown</a>
+      , <a href="#OnKeyUp">OnKeyUp</a> <span class="ver">[v1.1.32+]</span>
+      </li>
+      <li>
+	  <a href="#InputHookObj_OptionProperties"><u>Option Properties</u></a>
+	  - <a href="#BackspaceIsUndo">BackspaceIsUndo</a>
+      , <a href="#CaseSensitive">CaseSensitive</a>
+      , <a href="#FindAnywhere">FindAnywhere</a>
+      , <a href="#MinSendLevel">MinSendLevel</a>
+      , <a href="#NotifyNonText">NotifyNonText</a>
+      , <a href="#Timeout">Timeout</a>
+      , <a href="#VisibleNonText">VisibleNonText</a>
+      , <a href="#VisibleText">VisibleText</a>
+      </li>
+    </ul>
+    <li><a href="#EndReasons">EndReason</a></li>
+    <li><a href="#Remarks">Remarks</a></li>
+    <li><a href="#comparison">InputHook vs. Input</a></li>
+    <li><a href="#Related">Related</a></li>
+    <li><a href="#Examples">Examples</a></li>
+  </ul>
+</dd>
+</dl>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 
-  <dt>Options</dt>
+  <dt id="param_options">Options</dt>
   <dd>
     <p><u>A string of zero or more of the following letters (in any order, with optional spaces in between):</u></p>
     <p id="option-b"><strong>B</strong>: Sets <a href="#BackspaceIsUndo">BackspaceIsUndo</a> to false, which causes <kbd>Backspace</kbd> to be ignored.</p>
@@ -67,240 +116,262 @@ if (ih.Input = CtrlC)
 
 <h2 id="object">InputHook Object</h2>
 <p>The InputHook function returns an InputHook object, which has the following methods and properties.</p>
-<p>Methods:</p>
-<ul>
-  <li><a href="#KeyOpt">KeyOpt</a>: Sets options for a key or list of keys.</li>
-  <li><a href="#Start">Start</a>: Starts collecting input.</li>
-  <li><a href="#Stop">Stop</a>: Terminates the Input and sets EndReason to the word Stopped.</li>
-  <li><a href="#Wait">Wait</a>: Waits until the Input is terminated (InProgress is false).</li>
-</ul>
-<p>General Properties:</p>
-<ul>
-  <li><a href="#EndKey">EndKey</a>: Returns the name of the <a href="#EndKeys">end key</a> which was pressed to terminate the Input.</li>
-  <li><a href="#EndMods">EndMods</a>: Returns a string of the modifiers which were logically down when Input was terminated.</li>
-  <li><a href="#EndReason">EndReason</a>: Returns an <a href="#EndReasons">EndReason string</a> indicating how Input was terminated.</li>
-  <li><a href="#InProgress">InProgress</a>: Returns true if the Input is in progress and false otherwise.</li>
-  <li><a href="#Input">Input</a>: Returns any text collected since the last time Input was started.</li>
-  <li><a href="#Match">Match</a>: Returns the <em>MatchList</em> item which caused the Input to terminate.</li>
-  <li><a href="#OnEnd">OnEnd</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when Input is terminated.</li>
-  <li><a href="#OnChar">OnChar</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called after a character is added to the input buffer.</li>
-  <li><a href="#OnKeyDown">OnKeyDown</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is pressed.</li>
-  <li><a href="#OnKeyUp">OnKeyUp</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is released.</li>
-</ul>
-<p>Option Properties:</p>
-<ul>
-  <li><a href="#BackspaceIsUndo">BackspaceIsUndo</a>: Controls whether <kbd>Backspace</kbd> removes the most recently pressed character from the end of the Input buffer.</li>
-  <li><a href="#CaseSensitive">CaseSensitive</a>: Controls whether <em>MatchList</em> is case sensitive.</li>
-  <li><a href="#FindAnywhere">FindAnywhere</a>: Controls whether each match can be a substring of the input text.</li>
-  <li><a href="#MinSendLevel">MinSendLevel</a>: Retrieves or sets the minimum <a href="SendLevel.htm">send level</a> of input to collect.</li>
-  <li><a href="#NotifyNonText">NotifyNonText</a>: Controls whether the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks are called whenever a non-text key is pressed.</li>
-  <li><a href="#Timeout">Timeout</a>: Retrieves or sets the timeout value in seconds.</li>
-  <li><a href="#VisibleNonText">VisibleNonText</a>: Controls whether keys or key combinations which do not produce text are visible (not blocked).</li>
-  <li><a href="#VisibleText">VisibleText</a>: Controls whether keys or key combinations which produce text are visible (not blocked).</li>
-</ul>
 
-<div class="methodShort" id="KeyOpt"><h2>KeyOpt</h2>
-<p>Sets options for a key or list of keys.</p>
-<pre class="Syntax">InputHook.<span class="func">KeyOpt</span>(Keys, KeyOptions)</pre>
 <dl>
-  <dt>Keys</dt>
-  <dd><p>A list of keys. Braces are used to enclose key names, virtual key codes or scan codes, similar to the <a href="Send.htm">Send</a> command. For example, <code>{Enter}.{{}</code> would apply to <kbd>Enter</kbd>, <kbd>.</kbd> and <kbd>{</kbd>. Specifying a key by name, by <code>{vkNN}</code> or by <code>{scNNN}</code> may produce three different results; see below for details.</p>
-  <p id="all-keys">Specify the string <code>{All}</code> (case-insensitive) on its own to apply <em>KeyOptions</em> to all VK and all SC. KeyOpt may then be called a second time to remove options from specific keys.</p></dd>
-  <dt>KeyOptions</dt>
-  <dd><p>One or more of the following single-character options (spaces and tabs are ignored).</p>
-  <p id="KeyOpt-minus"><strong>-</strong> (minus): Removes any of the options following the <code>-</code>, up to the next <code>+</code>.</p>
-  <p id="KeyOpt-plus"><strong>+</strong> (plus): Cancels any previous <code>-</code>, otherwise has no effect.</p>
-  <p id="KeyOpt-e"><strong>E</strong>: End key. If enabled, pressing the key terminates Input, sets <a href="#EndReason">EndReason</a> to the word EndKey and the <a href="#EndKey">EndKey</a> property to the key's normalized name. Unlike the <em>EndKeys</em> parameter, the state of the Shift key is ignored. For example, <code>@</code> and <code>2</code> are both equivalent to <code>{vk32}</code> on the US keyboard layout.</p>
-  <p id="KeyOpt-i"><strong>I</strong>: Ignore text. Any text normally produced by this key is ignored, and the key is treated as a non-text key (see <a href="#VisibleNonText">VisibleNonText</a>). Has no effect if the key normally does not produce text.</p>
-  <p id="KeyOpt-n"><strong>N</strong>: Notify. Causes the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks to be called each time the key is pressed.</p>
-  <p id="KeyOpt-s"><strong>S</strong>: Suppresses (blocks) the key after processing it. This overrides <a href="#VisibleText">VisibleText</a> or <a href="#VisibleNonText">VisibleNonText</a> until <code>-S</code> is used. <code>+S</code> implies <code>-V</code>.</p>
-  <p id="KeyOpt-v"><strong>V</strong>: Visible. Prevents the key from being suppressed (blocked). This overrides <a href="#VisibleText">VisibleText</a> or <a href="#VisibleNonText">VisibleNonText</a> until <code>-V</code> is used. <code>+V</code> implies <code>-S</code>.</p>
+  <dt>Methods:</dt>
+  <dd>
+    <ul>
+      <li><a href="#KeyOpt">KeyOpt</a>: Sets options for a key or list of keys.</li>
+      <li><a href="#Start">Start</a>: Starts collecting input.</li>
+      <li><a href="#Stop">Stop</a>: Terminates the Input and sets EndReason to the word Stopped.</li>
+      <li><a href="#Wait">Wait</a>: Waits until the Input is terminated (InProgress is false).</li>
+    </ul>
+  </dd>
+  
+  <dt>General Properties:</dt>
+  <dd>
+    <ul>
+      <li><a href="#EndKey">EndKey</a>: Returns the name of the <a href="#EndKeys">end key</a> which was pressed to terminate the Input.</li>
+      <li><a href="#EndMods">EndMods</a>: Returns a string of the modifiers which were logically down when Input was terminated.</li>
+      <li><a href="#EndReason">EndReason</a>: Returns an <a href="#EndReasons">EndReason string</a> indicating how Input was terminated.</li>
+      <li><a href="#InProgress">InProgress</a>: Returns true if the Input is in progress and false otherwise.</li>
+      <li><a href="#Input">Input</a>: Returns any text collected since the last time Input was started.</li>
+      <li><a href="#Match">Match</a>: Returns the <em>MatchList</em> item which caused the Input to terminate.</li>
+      <li><a href="#OnEnd">OnEnd</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when Input is terminated.</li>
+      <li><a href="#OnChar">OnChar</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called after a character is added to the input buffer.</li>
+      <li><a href="#OnKeyDown">OnKeyDown</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is pressed.</li>
+      <li><a href="#OnKeyUp">OnKeyUp</a>: Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is released.</li>
+    </ul>
+  </dd>
+  
+  <dt>Option Properties:</dt>
+  <dd>
+    <ul>
+      <li><a href="#BackspaceIsUndo">BackspaceIsUndo</a>: Controls whether <kbd>Backspace</kbd> removes the most recently pressed character from the end of the Input buffer.</li>
+      <li><a href="#CaseSensitive">CaseSensitive</a>: Controls whether <em>MatchList</em> is case sensitive.</li>
+      <li><a href="#FindAnywhere">FindAnywhere</a>: Controls whether each match can be a substring of the input text.</li>
+      <li><a href="#MinSendLevel">MinSendLevel</a>: Retrieves or sets the minimum <a href="SendLevel.htm">send level</a> of input to collect.</li>
+      <li><a href="#NotifyNonText">NotifyNonText</a>: Controls whether the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks are called whenever a non-text key is pressed.</li>
+      <li><a href="#Timeout">Timeout</a>: Retrieves or sets the timeout value in seconds.</li>
+      <li><a href="#VisibleNonText">VisibleNonText</a>: Controls whether keys or key combinations which do not produce text are visible (not blocked).</li>
+      <li><a href="#VisibleText">VisibleText</a>: Controls whether keys or key combinations which produce text are visible (not blocked).</li>
+    </ul>
   </dd>
 </dl>
-<p id="KeyOpt-remarks">Options can be set by both virtual key code and scan code, and are accumulative.</p>
-<p>When a key is specified by name, the options are set either by VK or by SC. Where two physical keys share the same VK but differ by SC (such as <kbd>Up</kbd> and <kbd>NumpadUp</kbd>), they are handled by SC. By contrast, if a VK number is used, it will apply to any physical key which produces that VK (and this may vary over time as it depends on the active keyboard layout).</p>
-<p>Removing an option by VK number does not affect any options that were set by SC, or vice versa. However, when an option is removed by key name and that name is handled by VK, the option is also removed for the corresponding SC (according to the script's keyboard layout). This allows keys to be excluded by name after applying an option to <a href="#all-keys">all keys</a>.</p>
-<p>If <code>+V</code> is set by VK and <code>+S</code> is set by SC (or vice versa), <code>+V</code> takes precedence.</p>
-</div>
 
-<div class="methodShort" id="Start"><h2>Start</h2>
-<p>Starts collecting input.</p>
-<pre class="Syntax">InputHook.<span class="func">Start</span>()</pre>
-<p>Has no effect if the Input is already in progress.</p>
-<p>The newly started Input is placed on the top of the <a href="#stack">InputHook stack</a>, which allows it to override any previously started Input.</p>
-<p>This method installs the <a href="_InstallKeybdHook.htm">keyboard hook</a> (if it was not already).</p>
-</div>
-
-<div class="methodShort" id="Wait"><h2>Wait</h2>
-<p>Waits until the Input is terminated (<a href="#InProgress">InProgress</a> is false).</p>
-<pre class="Syntax">InputHook.<span class="func">Wait</span>(<span class="optional">MaxTime</span>)</pre>
 <dl>
-  <dt>MaxTime</dt>
-  <dd><p>The maximum number of seconds to wait. If Input is still in progress after <em>MaxTime</em> seconds, the method returns and does not terminate Input.</p></dd>
+<dt><h2 id="InputHookObj_Methods">InputHook Object - Methods</h2></dt>
+<dd>
+  <div class="methodShort" id="KeyOpt"><h2>KeyOpt</h2>
+  <p>Sets options for a key or list of keys.</p>
+  <pre class="Syntax">InputHook.<span class="func">KeyOpt</span>(Keys, KeyOptions)</pre>
+  <dl>
+    <dt>Keys</dt>
+    <dd><p>A list of keys. Braces are used to enclose key names, virtual key codes or scan codes, similar to the <a href="Send.htm">Send</a> command. For example, <code>{Enter}.{{}</code> would apply to <kbd>Enter</kbd>, <kbd>.</kbd> and <kbd>{</kbd>. Specifying a key by name, by <code>{vkNN}</code> or by <code>{scNNN}</code> may produce three different results; see below for details.</p>
+    <p id="all-keys">Specify the string <code>{All}</code> (case-insensitive) on its own to apply <em>KeyOptions</em> to all VK and all SC. KeyOpt may then be called a second time to remove options from specific keys.</p></dd>
+    <dt>KeyOptions</dt>
+    <dd><p>One or more of the following single-character options (spaces and tabs are ignored).</p>
+    <p id="KeyOpt-minus"><strong>-</strong> (minus): Removes any of the options following the <code>-</code>, up to the next <code>+</code>.</p>
+    <p id="KeyOpt-plus"><strong>+</strong> (plus): Cancels any previous <code>-</code>, otherwise has no effect.</p>
+    <p id="KeyOpt-e"><strong>E</strong>: End key. If enabled, pressing the key terminates Input, sets <a href="#EndReason">EndReason</a> to the word EndKey and the <a href="#EndKey">EndKey</a> property to the key's normalized name. Unlike the <em>EndKeys</em> parameter, the state of the Shift key is ignored. For example, <code>@</code> and <code>2</code> are both equivalent to <code>{vk32}</code> on the US keyboard layout.</p>
+    <p id="KeyOpt-i"><strong>I</strong>: Ignore text. Any text normally produced by this key is ignored, and the key is treated as a non-text key (see <a href="#VisibleNonText">VisibleNonText</a>). Has no effect if the key normally does not produce text.</p>
+    <p id="KeyOpt-n"><strong>N</strong>: Notify. Causes the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks to be called each time the key is pressed.</p>
+    <p id="KeyOpt-s"><strong>S</strong>: Suppresses (blocks) the key after processing it. This overrides <a href="#VisibleText">VisibleText</a> or <a href="#VisibleNonText">VisibleNonText</a> until <code>-S</code> is used. <code>+S</code> implies <code>-V</code>.</p>
+    <p id="KeyOpt-v"><strong>V</strong>: Visible. Prevents the key from being suppressed (blocked). This overrides <a href="#VisibleText">VisibleText</a> or <a href="#VisibleNonText">VisibleNonText</a> until <code>-V</code> is used. <code>+V</code> implies <code>-S</code>.</p>
+    </dd>
+  </dl>
+  <p id="KeyOpt-remarks">Options can be set by both virtual key code and scan code, and are accumulative.</p>
+  <p>When a key is specified by name, the options are set either by VK or by SC. Where two physical keys share the same VK but differ by SC (such as <kbd>Up</kbd> and <kbd>NumpadUp</kbd>), they are handled by SC. By contrast, if a VK number is used, it will apply to any physical key which produces that VK (and this may vary over time as it depends on the active keyboard layout).</p>
+  <p>Removing an option by VK number does not affect any options that were set by SC, or vice versa. However, when an option is removed by key name and that name is handled by VK, the option is also removed for the corresponding SC (according to the script's keyboard layout). This allows keys to be excluded by name after applying an option to <a href="#all-keys">all keys</a>.</p>
+  <p>If <code>+V</code> is set by VK and <code>+S</code> is set by SC (or vice versa), <code>+V</code> takes precedence.</p>
+  </div>
+  
+  <div class="methodShort" id="Start"><h2>Start</h2>
+  <p>Starts collecting input.</p>
+  <pre class="Syntax">InputHook.<span class="func">Start</span>()</pre>
+  <p>Has no effect if the Input is already in progress.</p>
+  <p>The newly started Input is placed on the top of the <a href="#stack">InputHook stack</a>, which allows it to override any previously started Input.</p>
+  <p>This method installs the <a href="_InstallKeybdHook.htm">keyboard hook</a> (if it was not already).</p>
+  </div>
+  
+  <div class="methodShort" id="Wait"><h2>Wait</h2>
+  <p>Waits until the Input is terminated (<a href="#InProgress">InProgress</a> is false).</p>
+  <pre class="Syntax">InputHook.<span class="func">Wait</span>(<span class="optional">MaxTime</span>)</pre>
+  <dl>
+    <dt>MaxTime</dt>
+    <dd><p>The maximum number of seconds to wait. If Input is still in progress after <em>MaxTime</em> seconds, the method returns and does not terminate Input.</p></dd>
+  </dl>
+  <p><strong>Returns</strong> <a href="#EndReason">EndReason</a>.</p>
+  </div>
+</dd>
+
+<dt><h2 id="InputHookObj_GeneralProperties">InputHook Object - General Properties</h2></dt>
+<dd>
+  <div class="methodShort" id="Stop"><h2>Stop</h2>
+  <p>Terminates the Input and sets <a href="#EndReason">EndReason</a> to the word Stopped.</p>
+  <pre class="Syntax">InputHook.<span class="func">Stop</span>()</pre>
+  <p>Has no effect if the Input is not in progress.</p>
+  </div>
+  
+  <div class="methodShort" id="EndKey"><h2>EndKey</h2>
+  <p>Returns the name of the <a href="#EndKeys">end key</a> which was pressed to terminate the Input.</p>
+  <pre class="Syntax">KeyName := InputHook.EndKey</pre>
+  <p>Note that EndKey returns the "normalized" name of the key regardless of how it was written in <em>EndKeys</em>. For example, <code>{Esc}</code> and <code>{vk1B}</code> both produce <code>Escape</code>. <a href="GetKey.htm">GetKeyName()</a> can be used to retrieve the normalized name.</p>
+  <p>If the <a href="#E">E option</a> was used, EndKey returns the actual character which was typed (if applicable). Otherwise, the key name is determined according to the script's active keyboard layout.</p>
+  <p>EndKey returns an empty string if <a href="#EndReason">EndReason</a> is not "EndKey".</p>
+  </div>
+  
+  <div class="methodShort" id="EndMods"><h2>EndMods</h2>
+  <p>Returns a string of the modifiers which were logically down when Input was terminated.</p>
+  <pre class="Syntax">Mods := InputHook.EndMods</pre>
+  <p>If all modifiers were logically down (pressed), the full string is:</p>
+  <pre>&lt;^&gt;^&lt;!&gt;!&lt;+&gt;+&lt;#&gt;#</pre>
+  <p>These modifiers have the same meaning as with <a href="../Hotkeys.htm">hotkeys</a>. Each modifier is always qualified with &lt; (left) or &gt; (right). The corresponding key names are: LCtrl, RCtrl, LAlt, RAlt, LShift, RShift, LWin, RWin.</p>
+  <p><a href="InStr.htm">InStr()</a> can be used to check whether a given modifier (such as <code>&gt;!</code> or <code>^</code>) is present. The following line can be used to convert <em>Mods</em> to a string of neutral modifiers, such as <code>^!+#</code>:</p>
+  <pre>Mods := RegExReplace(Mods, "[&lt;&gt;](.)(?:&gt;\1)?", "$1")</pre>
+  <p>Due to split-second timing, this property may be more reliable than <a href="GetKeyState.htm#function">GetKeyState()</a> even if it is used immediately after Input terminates, or in the <a href="#OnEnd">OnEnd</a> callback.</p>
+  </div>
+  
+  <div class="methodShort" id="EndReason"><h2>EndReason</h2>
+  <p>Returns an <a href="#EndReasons">EndReason string</a> indicating how Input was terminated.</p>
+  <pre class="Syntax">Reason := InputHook.EndReason</pre>
+  <p>Returns an empty string if the Input is still in progress.</p>
+  </div>
+  
+  <div class="methodShort" id="InProgress"><h2>InProgress</h2>
+  <p>Returns true if the Input is in progress and false otherwise.</p>
+  <pre class="Syntax">Boolean := InputHook.InProgress</pre>
+  </div>
+  
+  <div class="methodShort" id="Input"><h2>Input</h2>
+  <p>Returns any text collected since the last time Input was started.</p>
+  <pre class="Syntax">String := InputHook.Input</pre>
+  <p>This property can be used while the Input is in progress, or after it has ended.</p>
+  </div>
+  
+  <div class="methodShort" id="Match"><h2>Match</h2>
+  <p>Returns the <em><a href="#MatchList">MatchList</a></em> item which caused the Input to terminate.</p>
+  <pre class="Syntax">String := InputHook.Match</pre>
+  <p><strong>Returns</strong> the matched item with its original case, which may differ from what the user typed if the <strong>C</strong> option was omitted. Returns an empty string if <a href="#EndReason">EndReason</a> is not "Match".</p>
+  </div>
+  
+  <div class="methodShort" id="OnEnd"><h2>OnEnd</h2>
+  <p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when Input is terminated.</p>
+  <pre class="Syntax">MyFunc := InputHook.OnEnd</pre>
+  <pre class="Syntax">InputHook.OnEnd := MyFunc</pre>
+  <p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
+  <p>The function is passed one parameter: a reference to the InputHook object.</p>
+  <p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
+  </div>
+  
+  <div class="methodShort" id="OnChar"><h2>OnChar</h2>
+  <p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called after a character is added to the input buffer.</p>
+  <pre class="Syntax">MyFunc := InputHook.OnChar</pre>
+  <pre class="Syntax">InputHook.OnChar := MyFunc</pre>
+  <p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
+  <p>The function is passed the following parameters: <code>InputHook, Char</code>. <em>Char</em> is a string containing the character or characters.</p>
+  <p>The presence of multiple characters indicates that a dead key was used prior to the last keypress, but the two keys could not be transliterated to a single character. For example, on some keyboard layouts <kbd>`</kbd><kbd>e</kbd> produces <code>è</code> while <kbd>`</kbd><kbd>z</kbd> produces <code>`z</code>.</p>
+  <p>The function is never called when an end key is pressed.</p>
+  </div>
+  
+  <div class="methodShort" id="OnKeyDown"><h2>OnKeyDown</h2>
+  <p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is pressed.</p>
+  <pre class="Syntax">MyFunc := InputHook.OnKeyDown</pre>
+  <pre class="Syntax">InputHook.OnKeyDown := MyFunc</pre>
+  <p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
+  <p>Key-down notifications must first be enabled by <a href="#KeyOpt">KeyOpt</a> or <a href="#NotifyNonText">NotifyNonText</a>.</p>
+  <p>The function is passed the following parameters: <code>InputHook, VK, SC</code>. <em>VK</em> and <em>SC</em> are integers. To retrieve the key name (if any), use <code>GetKeyName(Format("vk{:x}sc{:x}", VK, SC))</code>.</p>
+  <p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
+  <p>The function is never called when an end key is pressed.</p>
+  </div>
+  
+  <div class="methodShort" id="OnKeyUp"><h2>OnKeyUp <span class="ver">[v1.1.32+]</span></h2>
+  <p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is released.</p>
+  <pre class="Syntax">MyFunc := InputHook.OnKeyUp</pre>
+  <pre class="Syntax">InputHook.OnKeyUp := MyFunc</pre>
+  <p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
+  <p>Key-up notifications must first be enabled by <a href="#KeyOpt">KeyOpt</a> or <a href="#NotifyNonText">NotifyNonText</a>. Whether a key is considered text or non-text is determined when the key is pressed. If an InputHook detects a key-up without having detected key-down, it is considered non-text.</p>
+  <p>The function is passed the following parameters: <code>InputHook, VK, SC</code>. <em>VK</em> and <em>SC</em> are integers. To retrieve the key name (if any), use <code>GetKeyName(Format("vk{:x}sc{:x}", VK, SC))</code>.</p>
+  <p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
+  </div>
+</dd>
+  
+<dt><h2 id="InputHookObj_OptionProperties">InputHook Object - Option Properties</h2></dt>
+<dd>
+  <div class="methodShort" id="BackspaceIsUndo"><h2>BackspaceIsUndo</h2>
+  <p>Controls whether <kbd>Backspace</kbd> removes the most recently pressed character from the end of the Input buffer.</p>
+  <pre class="Syntax">Boolean := InputHook.BackspaceIsUndo</pre>
+  <pre class="Syntax">InputHook.BackspaceIsUndo := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: true. Option <strong>B</strong> sets the value to false.</p>
+  <p>When <kbd>Backspace</kbd> acts as undo, it is treated as a text entry key. Specifically, whether the key is suppressed depends on <a href="#VisibleText">VisibleText</a> rather than <a href="#VisibleNonText">VisibleNonText</a>.</p>
+  <p><kbd>Backspace</kbd> is always ignored if pressed in combination with a modifier key such as <kbd>Ctrl</kbd> (the logical modifier state is checked rather than the physical state).</p>
+  <p class="warning"><strong>Note:</strong> If the input text is visible (such as in an editor) and the arrow keys or other means are used to navigate within it, <kbd>Backspace</kbd> will still remove the last character rather than the one behind the caret (insertion point).</p>
+  </div>
+  
+  <div class="methodShort" id="CaseSensitive"><h2>CaseSensitive</h2>
+  <p>Controls whether <em>MatchList</em> is case sensitive.</p>
+  <pre class="Syntax">Boolean := InputHook.CaseSensitive</pre>
+  <pre class="Syntax">InputHook.CaseSensitive := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>C</strong> sets the value to true.</p>
+  </div>
+  
+  <div class="methodShort" id="FindAnywhere"><h2>FindAnywhere</h2>
+  <p>Controls whether each match can be a substring of the input text.</p>
+  <pre class="Syntax">Boolean := InputHook.FindAnywhere</pre>
+  <pre class="Syntax">InputHook.FindAnywhere := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>*</strong> sets the value to true.</p>
+  <p>If true, a match can be found anywhere within what the user types (the match can be a substring of the input text). If false, the entirety of what the user types must match one of the <em>MatchList</em> phrases. In both cases, one of the <em>MatchList</em> phrases must be typed in full.</p>
+  </div>
+  
+  <div class="methodShort" id="MinSendLevel"><h2>MinSendLevel</h2>
+  <p>Retrieves or sets the minimum <a href="SendLevel.htm">send level</a> of input to collect.</p>
+  <pre class="Syntax">Level := InputHook.MinSendLevel</pre>
+  <pre class="Syntax">InputHook.MinSendLevel := Level</pre>
+  <p>Type: <a href="../Concepts.htm#numbers">Integer</a>. Default: 0. Option <strong>I</strong> sets the value to 1 (or a given value).</p>
+  <p><em>Level</em> should be an integer between 0 and 101. Events which have a send level <em>lower</em> than this value are ignored. For example, a value of 101 causes all input generated by <a href="Send.htm">SendEvent</a> to be ignored, while a value of 1 only ignores input at the default send level (zero).</p>
+  <p>The <a href="Send.htm#SendInput">SendInput</a> and <a href="Send.htm#SendPlay">SendPlay</a> methods are always ignored, regardless of this setting. Input generated by any source other than AutoHotkey is never ignored as a result of this setting.</p>
+  </div>
+  
+  <div class="methodShort" id="NotifyNonText"><h2>NotifyNonText</h2>
+  <p>Controls whether the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks are called whenever a non-text key is pressed.</p>
+  <pre class="Syntax">Boolean := InputHook.NotifyNonText</pre>
+  <pre class="Syntax">InputHook.NotifyNonText := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false.</p>
+  <p>Setting this to true enables notifications for all keypresses which do not produce text, such as when pressing <kbd>Left</kbd> or <kbd>Alt</kbd>+<kbd>F</kbd>. Setting this property does not affect a key's <a href="#KeyOpt">options</a>, since the production of text depends on the active window's keyboard layout at the time the key is pressed. </p>
+  <p>NotifyNonText is applied to key-up events by considering whether a previous key-down with a matching VK code was classified as text or non-text. For example, if NotifyNonText is true, pressing <kbd>Ctrl</kbd>+<kbd>A</kbd> will produce <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> calls for both <kbd>Ctrl</kbd> and <kbd>A</kbd>, while pressing <kbd>A</kbd> on its own will not call OnKeyDown or OnKeyUp unless <a href="#KeyOpt">KeyOpt</a> has been used to enable notifications for that key.</p>
+  <p>See <a href="#VisibleText">VisibleText</a> for details about which keys are counted as producing text.</p>
+  </div>
+  
+  <div class="methodShort" id="Timeout"><h2>Timeout</h2>
+  <p>Retrieves or sets the timeout value in seconds.</p>
+  <pre class="Syntax">Seconds := InputHook.Timeout</pre>
+  <pre class="Syntax">InputHook.Timeout := Seconds</pre>
+  <p>Type: <a href="../Concepts.htm#numbers">Float</a>. Default: 0.0 (none). Option <strong>T</strong> also sets the timeout value.</p>
+  <p>The timeout period ordinarily starts when <a href="#Start">Start</a> is called, but will restart if this property is assigned a value while Input is in progress. If Input is still in progress when the timeout period elapses, it is terminated and <a href="#EndReason">EndReason</a> is set to the word Timeout.</p>
+  </div>
+  
+  <div class="methodShort" id="VisibleNonText"><h2>VisibleNonText</h2>
+  <p>Controls whether keys or key combinations which do not produce text are visible (not blocked).</p>
+  <pre class="Syntax">Boolean := InputHook.VisibleNonText</pre>
+  <pre class="Syntax">InputHook.VisibleNonText := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: true. Option <strong>V</strong> sets the value to true.</p>
+  <p>If true, keys and key combinations which do not produce text may trigger hotkeys or be passed on to the active window. If false, they are blocked.</p>
+  <p>See <a href="#VisibleText">VisibleText</a> for details about which keys are counted as producing text.</p>
+  </div>
+  
+  <div class="methodShort" id="VisibleText"><h2>VisibleText</h2>
+  <p>Controls whether keys or key combinations which produce text are visible (not blocked).</p>
+  <pre class="Syntax">Boolean := InputHook.VisibleText</pre>
+  <pre class="Syntax">InputHook.VisibleText := Boolean</pre>
+  <p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>V</strong> sets the value to true.</p>
+  <p>If true, keys and key combinations which produce text may trigger hotkeys or be passed on to the active window. If false, they are blocked.</p>
+  <p>Any keystrokes which cause text to be appended to the Input buffer are counted as producing text, even if they do not normally do so in other applications. For instance, <kbd>Ctrl</kbd>+<kbd>A</kbd> produces text if the <a href="#option-m"><strong>M</strong> option</a> is used, and <kbd>Esc</kbd> produces the control character <code>Chr(27)</code>.</p>
+  <p>Dead keys are counted as producing text, although they do not typically produce an immediate effect. Pressing a dead key might also cause the following key to produce text (if only the dead key's character).</p>
+  <p><kbd>Backspace</kbd> is counted as producing text only when it <a href="#BackspaceIsUndo">acts as undo</a>.</p>
+  <p>The <a href="../KeyList.htm#modifier">standard modifier keys</a> and CapsLock, NumLock and ScrollLock are always visible (not blocked).</p>
+  </div>
+</dd>
 </dl>
-<p><strong>Returns</strong> <a href="#EndReason">EndReason</a>.</p>
-</div>
-
-<div class="methodShort" id="Stop"><h2>Stop</h2>
-<p>Terminates the Input and sets <a href="#EndReason">EndReason</a> to the word Stopped.</p>
-<pre class="Syntax">InputHook.<span class="func">Stop</span>()</pre>
-<p>Has no effect if the Input is not in progress.</p>
-</div>
-
-<div class="methodShort" id="EndKey"><h2>EndKey</h2>
-<p>Returns the name of the <a href="#EndKeys">end key</a> which was pressed to terminate the Input.</p>
-<pre class="Syntax">KeyName := InputHook.EndKey</pre>
-<p>Note that EndKey returns the "normalized" name of the key regardless of how it was written in <em>EndKeys</em>. For example, <code>{Esc}</code> and <code>{vk1B}</code> both produce <code>Escape</code>. <a href="GetKey.htm">GetKeyName()</a> can be used to retrieve the normalized name.</p>
-<p>If the <a href="#E">E option</a> was used, EndKey returns the actual character which was typed (if applicable). Otherwise, the key name is determined according to the script's active keyboard layout.</p>
-<p>EndKey returns an empty string if <a href="#EndReason">EndReason</a> is not "EndKey".</p>
-</div>
-
-<div class="methodShort" id="EndMods"><h2>EndMods</h2>
-<p>Returns a string of the modifiers which were logically down when Input was terminated.</p>
-<pre class="Syntax">Mods := InputHook.EndMods</pre>
-<p>If all modifiers were logically down (pressed), the full string is:</p>
-<pre>&lt;^&gt;^&lt;!&gt;!&lt;+&gt;+&lt;#&gt;#</pre>
-<p>These modifiers have the same meaning as with <a href="../Hotkeys.htm">hotkeys</a>. Each modifier is always qualified with &lt; (left) or &gt; (right). The corresponding key names are: LCtrl, RCtrl, LAlt, RAlt, LShift, RShift, LWin, RWin.</p>
-<p><a href="InStr.htm">InStr()</a> can be used to check whether a given modifier (such as <code>&gt;!</code> or <code>^</code>) is present. The following line can be used to convert <em>Mods</em> to a string of neutral modifiers, such as <code>^!+#</code>:</p>
-<pre>Mods := RegExReplace(Mods, "[&lt;&gt;](.)(?:&gt;\1)?", "$1")</pre>
-<p>Due to split-second timing, this property may be more reliable than <a href="GetKeyState.htm#function">GetKeyState()</a> even if it is used immediately after Input terminates, or in the <a href="#OnEnd">OnEnd</a> callback.</p>
-</div>
-
-<div class="methodShort" id="EndReason"><h2>EndReason</h2>
-<p>Returns an <a href="#EndReasons">EndReason string</a> indicating how Input was terminated.</p>
-<pre class="Syntax">Reason := InputHook.EndReason</pre>
-<p>Returns an empty string if the Input is still in progress.</p>
-</div>
-
-<div class="methodShort" id="InProgress"><h2>InProgress</h2>
-<p>Returns true if the Input is in progress and false otherwise.</p>
-<pre class="Syntax">Boolean := InputHook.InProgress</pre>
-</div>
-
-<div class="methodShort" id="Input"><h2>Input</h2>
-<p>Returns any text collected since the last time Input was started.</p>
-<pre class="Syntax">String := InputHook.Input</pre>
-<p>This property can be used while the Input is in progress, or after it has ended.</p>
-</div>
-
-<div class="methodShort" id="Match"><h2>Match</h2>
-<p>Returns the <em><a href="#MatchList">MatchList</a></em> item which caused the Input to terminate.</p>
-<pre class="Syntax">String := InputHook.Match</pre>
-<p><strong>Returns</strong> the matched item with its original case, which may differ from what the user typed if the <strong>C</strong> option was omitted. Returns an empty string if <a href="#EndReason">EndReason</a> is not "Match".</p>
-</div>
-
-<div class="methodShort" id="OnEnd"><h2>OnEnd</h2>
-<p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when Input is terminated.</p>
-<pre class="Syntax">MyFunc := InputHook.OnEnd</pre>
-<pre class="Syntax">InputHook.OnEnd := MyFunc</pre>
-<p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
-<p>The function is passed one parameter: a reference to the InputHook object.</p>
-<p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
-</div>
-
-<div class="methodShort" id="OnChar"><h2>OnChar</h2>
-<p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called after a character is added to the input buffer.</p>
-<pre class="Syntax">MyFunc := InputHook.OnChar</pre>
-<pre class="Syntax">InputHook.OnChar := MyFunc</pre>
-<p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
-<p>The function is passed the following parameters: <code>InputHook, Char</code>. <em>Char</em> is a string containing the character or characters.</p>
-<p>The presence of multiple characters indicates that a dead key was used prior to the last keypress, but the two keys could not be transliterated to a single character. For example, on some keyboard layouts <kbd>`</kbd><kbd>e</kbd> produces <code>è</code> while <kbd>`</kbd><kbd>z</kbd> produces <code>`z</code>.</p>
-<p>The function is never called when an end key is pressed.</p>
-</div>
-
-<div class="methodShort" id="OnKeyDown"><h2>OnKeyDown</h2>
-<p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is pressed.</p>
-<pre class="Syntax">MyFunc := InputHook.OnKeyDown</pre>
-<pre class="Syntax">InputHook.OnKeyDown := MyFunc</pre>
-<p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
-<p>Key-down notifications must first be enabled by <a href="#KeyOpt">KeyOpt</a> or <a href="#NotifyNonText">NotifyNonText</a>.</p>
-<p>The function is passed the following parameters: <code>InputHook, VK, SC</code>. <em>VK</em> and <em>SC</em> are integers. To retrieve the key name (if any), use <code>GetKeyName(Format("vk{:x}sc{:x}", VK, SC))</code>.</p>
-<p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
-<p>The function is never called when an end key is pressed.</p>
-</div>
-
-<div class="methodShort" id="OnKeyUp"><h2>OnKeyUp <span class="ver">[v1.1.32+]</span></h2>
-<p>Retrieves or sets the <a href="../objects/Functor.htm">function object</a> which is called when a notification-enabled key is released.</p>
-<pre class="Syntax">MyFunc := InputHook.OnKeyUp</pre>
-<pre class="Syntax">InputHook.OnKeyUp := MyFunc</pre>
-<p>Type: <a href="../objects/Functor.htm">function object</a> or <a href="../Concepts.htm#nothing">empty string</a>. Default: empty string.</p>
-<p>Key-up notifications must first be enabled by <a href="#KeyOpt">KeyOpt</a> or <a href="#NotifyNonText">NotifyNonText</a>. Whether a key is considered text or non-text is determined when the key is pressed. If an InputHook detects a key-up without having detected key-down, it is considered non-text.</p>
-<p>The function is passed the following parameters: <code>InputHook, VK, SC</code>. <em>VK</em> and <em>SC</em> are integers. To retrieve the key name (if any), use <code>GetKeyName(Format("vk{:x}sc{:x}", VK, SC))</code>.</p>
-<p>The function is called as a new <a href="../misc/Threads.htm">thread</a>, so starts off fresh with the default values for settings such as <a href="SendMode.htm">SendMode</a> and <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a>.</p>
-</div>
-
-<div class="methodShort" id="BackspaceIsUndo"><h2>BackspaceIsUndo</h2>
-<p>Controls whether <kbd>Backspace</kbd> removes the most recently pressed character from the end of the Input buffer.</p>
-<pre class="Syntax">Boolean := InputHook.BackspaceIsUndo</pre>
-<pre class="Syntax">InputHook.BackspaceIsUndo := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: true. Option <strong>B</strong> sets the value to false.</p>
-<p>When <kbd>Backspace</kbd> acts as undo, it is treated as a text entry key. Specifically, whether the key is suppressed depends on <a href="#VisibleText">VisibleText</a> rather than <a href="#VisibleNonText">VisibleNonText</a>.</p>
-<p><kbd>Backspace</kbd> is always ignored if pressed in combination with a modifier key such as <kbd>Ctrl</kbd> (the logical modifier state is checked rather than the physical state).</p>
-<p class="warning"><strong>Note:</strong> If the input text is visible (such as in an editor) and the arrow keys or other means are used to navigate within it, <kbd>Backspace</kbd> will still remove the last character rather than the one behind the caret (insertion point).</p>
-</div>
-
-<div class="methodShort" id="CaseSensitive"><h2>CaseSensitive</h2>
-<p>Controls whether <em>MatchList</em> is case sensitive.</p>
-<pre class="Syntax">Boolean := InputHook.CaseSensitive</pre>
-<pre class="Syntax">InputHook.CaseSensitive := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>C</strong> sets the value to true.</p>
-</div>
-
-<div class="methodShort" id="FindAnywhere"><h2>FindAnywhere</h2>
-<p>Controls whether each match can be a substring of the input text.</p>
-<pre class="Syntax">Boolean := InputHook.FindAnywhere</pre>
-<pre class="Syntax">InputHook.FindAnywhere := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>*</strong> sets the value to true.</p>
-<p>If true, a match can be found anywhere within what the user types (the match can be a substring of the input text). If false, the entirety of what the user types must match one of the <em>MatchList</em> phrases. In both cases, one of the <em>MatchList</em> phrases must be typed in full.</p>
-</div>
-
-<div class="methodShort" id="MinSendLevel"><h2>MinSendLevel</h2>
-<p>Retrieves or sets the minimum <a href="SendLevel.htm">send level</a> of input to collect.</p>
-<pre class="Syntax">Level := InputHook.MinSendLevel</pre>
-<pre class="Syntax">InputHook.MinSendLevel := Level</pre>
-<p>Type: <a href="../Concepts.htm#numbers">Integer</a>. Default: 0. Option <strong>I</strong> sets the value to 1 (or a given value).</p>
-<p><em>Level</em> should be an integer between 0 and 101. Events which have a send level <em>lower</em> than this value are ignored. For example, a value of 101 causes all input generated by <a href="Send.htm">SendEvent</a> to be ignored, while a value of 1 only ignores input at the default send level (zero).</p>
-<p>The <a href="Send.htm#SendInput">SendInput</a> and <a href="Send.htm#SendPlay">SendPlay</a> methods are always ignored, regardless of this setting. Input generated by any source other than AutoHotkey is never ignored as a result of this setting.</p>
-</div>
-
-<div class="methodShort" id="NotifyNonText"><h2>NotifyNonText</h2>
-<p>Controls whether the <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> callbacks are called whenever a non-text key is pressed.</p>
-<pre class="Syntax">Boolean := InputHook.NotifyNonText</pre>
-<pre class="Syntax">InputHook.NotifyNonText := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false.</p>
-<p>Setting this to true enables notifications for all keypresses which do not produce text, such as when pressing <kbd>Left</kbd> or <kbd>Alt</kbd>+<kbd>F</kbd>. Setting this property does not affect a key's <a href="#KeyOpt">options</a>, since the production of text depends on the active window's keyboard layout at the time the key is pressed. </p>
-<p>NotifyNonText is applied to key-up events by considering whether a previous key-down with a matching VK code was classified as text or non-text. For example, if NotifyNonText is true, pressing <kbd>Ctrl</kbd>+<kbd>A</kbd> will produce <a href="#OnKeyDown">OnKeyDown</a> and <a href="#OnKeyUp">OnKeyUp</a> calls for both <kbd>Ctrl</kbd> and <kbd>A</kbd>, while pressing <kbd>A</kbd> on its own will not call OnKeyDown or OnKeyUp unless <a href="#KeyOpt">KeyOpt</a> has been used to enable notifications for that key.</p>
-<p>See <a href="#VisibleText">VisibleText</a> for details about which keys are counted as producing text.</p>
-</div>
-
-<div class="methodShort" id="Timeout"><h2>Timeout</h2>
-<p>Retrieves or sets the timeout value in seconds.</p>
-<pre class="Syntax">Seconds := InputHook.Timeout</pre>
-<pre class="Syntax">InputHook.Timeout := Seconds</pre>
-<p>Type: <a href="../Concepts.htm#numbers">Float</a>. Default: 0.0 (none). Option <strong>T</strong> also sets the timeout value.</p>
-<p>The timeout period ordinarily starts when <a href="#Start">Start</a> is called, but will restart if this property is assigned a value while Input is in progress. If Input is still in progress when the timeout period elapses, it is terminated and <a href="#EndReason">EndReason</a> is set to the word Timeout.</p>
-</div>
-
-<div class="methodShort" id="VisibleNonText"><h2>VisibleNonText</h2>
-<p>Controls whether keys or key combinations which do not produce text are visible (not blocked).</p>
-<pre class="Syntax">Boolean := InputHook.VisibleNonText</pre>
-<pre class="Syntax">InputHook.VisibleNonText := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: true. Option <strong>V</strong> sets the value to true.</p>
-<p>If true, keys and key combinations which do not produce text may trigger hotkeys or be passed on to the active window. If false, they are blocked.</p>
-<p>See <a href="#VisibleText">VisibleText</a> for details about which keys are counted as producing text.</p>
-</div>
-
-<div class="methodShort" id="VisibleText"><h2>VisibleText</h2>
-<p>Controls whether keys or key combinations which produce text are visible (not blocked).</p>
-<pre class="Syntax">Boolean := InputHook.VisibleText</pre>
-<pre class="Syntax">InputHook.VisibleText := Boolean</pre>
-<p>Type: <a href="../Concepts.htm#boolean">Integer (boolean)</a>. Default: false. Option <strong>V</strong> sets the value to true.</p>
-<p>If true, keys and key combinations which produce text may trigger hotkeys or be passed on to the active window. If false, they are blocked.</p>
-<p>Any keystrokes which cause text to be appended to the Input buffer are counted as producing text, even if they do not normally do so in other applications. For instance, <kbd>Ctrl</kbd>+<kbd>A</kbd> produces text if the <a href="#option-m"><strong>M</strong> option</a> is used, and <kbd>Esc</kbd> produces the control character <code>Chr(27)</code>.</p>
-<p>Dead keys are counted as producing text, although they do not typically produce an immediate effect. Pressing a dead key might also cause the following key to produce text (if only the dead key's character).</p>
-<p><kbd>Backspace</kbd> is counted as producing text only when it <a href="#BackspaceIsUndo">acts as undo</a>.</p>
-<p>The <a href="../KeyList.htm#modifier">standard modifier keys</a> and CapsLock, NumLock and ScrollLock are always visible (not blocked).</p>
-</div>
 
 <h2 id="EndReasons">EndReason</h2>
 <p>The EndReason property returns one of the following strings:</p>


### PR DESCRIPTION
- Added Table Of Contents to top of page
- InputHook Object section
	- put `<ul>` inside of `<dl>,<dt><dd>` tags to clean it up
- InputHook Object (`<div class="methodShort">`) sections
	- In order to help break up the space...
	- added new sections, Methods, General Properties, Option Properties
	- added `<dl><dd>` tags for each section
	- added `<h2>` section headers in the <dt> tags of the their respective blocks

PS:	It looks like a got rid of a lot of lines, but I actually just "tabbed" them with 2 spaces; as they now sit inside of `<dl><dd>` tags.