### PR TITLE
fix non-flashings keys ? and : KeyboardOnScreen.ahk #539

### DIFF
--- a/docs/scripts/KeyboardOnScreen.ahk
+++ b/docs/scripts/KeyboardOnScreen.ahk
@@ -486,7 +486,7 @@ Loop {
     k_char := Chr(k_ASCII)
 
     ; These keys are only accessible using modifier keys; that's why we're escaping them.
-    if k_char not in <,>,^,`,`?,`:
+    if k_char not in <,>,^,`,,?,:,@
         Hotkey, ~*%k_char%, flashButton
         ; In the above, the asterisk prefix allows the key to be detected regardless
         ; of whether the user is holding down modifier keys such as Control and Shift.

--- a/docs/scripts/KeyboardOnScreen.ahk
+++ b/docs/scripts/KeyboardOnScreen.ahk
@@ -486,7 +486,7 @@ Loop {
     k_char := Chr(k_ASCII)
 
     ; These keys are only accessible using modifier keys; that's why we're escaping them.
-    if k_char not in <,>,^,`,
+    if k_char not in <,>,^,`,`?,`:
         Hotkey, ~*%k_char%, flashButton
         ; In the above, the asterisk prefix allows the key to be detected regardless
         ; of whether the user is holding down modifier keys such as Control and Shift.


### PR DESCRIPTION
- [x] line 489: added "?" and ":" to keys that are only accessible with modifier keys (so we can escaped them)
- [x] tested in Win10 (US English); flashing of keys now working as intended