### PR TITLE
Fixed #541 KeyboardOnScreen.ahk: corrected symbol for right arrow key

### DIFF
--- a/docs/scripts/KeyboardOnScreen.ahk
+++ b/docs/scripts/KeyboardOnScreen.ahk
@@ -202,7 +202,7 @@ labels := { ""     : ""
     , "PgUp"       : "PU"
     , "RAlt"       : "Alt" zwnbs
     , "RCtrl"      : "Ctrl" zwnbs
-    , "Right"      : Chr(0x27A4)
+    , "Right"      : Chr(0x2B9E)
     , "RShift"     : "Shift" zwnbs
     , "RWin"       : "Win" zwnbs
     , "Tab"        : Chr(0x2B7E)


### PR DESCRIPTION
- [x] line 214: replaced the character for right arrow key with one that matches the other keys