### PR TITLE
Adding note about modifying input parameters to regex functions during callout

### DIFF
--- a/docs/misc/RegExCallout.htm
+++ b/docs/misc/RegExCallout.htm
@@ -63,7 +63,8 @@ Callout(m, *) {
     return 1
 }</pre>
 <p>In the above example, <em>Callout</em> is called once for each substring which matches the part of the pattern preceding the RegEx callout. <span class="regex">\b</span> is used to exclude incomplete words in matches such as <em>The quic</em>, <em>The qui</em>, <em>The qu</em>, etc.</p>
-
+<p>If any of the input parameters to a <em>RegEx</em> function is modified during a callout, the behaviour is undefined.</p>
+    
 <h2 id="EventInfo">EventInfo</h2>
 
 <p>Additional information is available by accessing the pcre_callout_block structure via <b>A_EventInfo</b>.</p>


### PR DESCRIPTION
**Reason**, regex functions do not copy content of input parameters (at least not all string parameters), thus, modifying them during a callout risk undefined behaviour if the content is referenced after the callout returns.

Updating regex functions to copy input to allow modification of input parameters during callouts doesn't seem worth the costs (code size, performance, maintainability). Instead, input can be copied on the script side if desired.