### PR TITLE
Fixing static example

### DIFF
--- a/docs/Functions.htm
+++ b/docs/Functions.htm
@@ -228,10 +228,11 @@ MsgBox Join("`n", <b class="blue">substrings*</b>)</pre>
     if FirstCallToUs  <em>; Create a static array during the first call, but not on subsequent calls.</em>
     {
         FirstCallToUs := false
+        StaticArray := []
         Loop 10
-            StaticArray%A_Index% := "Value #" . A_Index
+            StaticArray.Push("Value #" . A_Index)
     }
-    return StaticArray%WhichItemNumber%
+    return StaticArray[WhichItemNumber]
 }</pre>
 <p>In assume-static mode, any variable that should not be static must be declared as local or global (with the same exceptions as for <a href="#AssumeLocal">assume-local mode</a>).</p>
 


### PR DESCRIPTION
Using an array instead of dynamic variable creation.