### PR TITLE
docs(Type): add mention about classes and arrays

### DIFF
--- a/docs/commands/Type.htm
+++ b/docs/commands/Type.htm
@@ -23,6 +23,11 @@
   <li>Integer</li>
   <li>Float</li>
 </ul>
+<p>It may also detect other <a href="../objects/index.htm">built-in classes</a>, such as:</p>
+<ul>
+  <li>Array</li>
+  <li>Object</li>
+</ul>
 <p>The algorithm for determining a value's class name can be approximated as shown below:</p>
 <pre>
 TypeOf(Value)


### PR DESCRIPTION
This adds a mention that `Type(Value)` can also work with arrays and objects.