### PR TITLE
Update _IfWinActive.htm

### DIFF
--- a/docs/commands/_IfWinActive.htm
+++ b/docs/commands/_IfWinActive.htm
@@ -20,7 +20,7 @@
 <span class="func">#IfWinExist</span> <span class="optional">WinTitle, WinText</span>
 <span class="func">#IfWinNotActive</span> <span class="optional">WinTitle, WinText</span>
 <span class="func">#IfWinNotExist</span> <span class="optional">WinTitle, WinText</span>
-<a href="_If.htm">#If <span class="optional">, Expression</span></a>
+<a href="_If.htm">#If <span class="optional">Expression</span></a>
 </pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>


### PR DESCRIPTION
Page `#If` shows syntax: `#If [Expression]`
Page `#IfWinActive` shows syntax: `#If [, Expression]`

Where is truth? I see all `#Directives` does not have optional comma in description.