### PR TITLE
Update _If.htm

### DIFF
--- a/docs/commands/_If.htm
+++ b/docs/commands/_If.htm
@@ -16,7 +16,7 @@
 
 <p>Creates context-sensitive <a href="../Hotkeys.htm">hotkeys</a> and <a href="../Hotstrings.htm">hotstrings</a>. Such hotkeys perform a different action (or none at all) depending on the result of an expression.</p>
 
-<pre class="Syntax"><span class="func">#If</span> <span class="optional">Expression</span></pre>
+<pre class="Syntax"><span class="func">#If</span> <span class="optional">, Expression</span></pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
All mentions of `#If` had optional comma, but this page does not have it.