### PR TITLE
Update v2 Tutorial's Object Brace Syntax.htm

### DIFF
--- a/docs/Tutorial.htm
+++ b/docs/Tutorial.htm
@@ -528,8 +528,8 @@ if Var1 &lt; Var2  <em>; Check if a variable is lesser than another.</em></pre>
     </dd>
     <dt>Brace syntax</dt>
     <dd>
-        <pre class="NoIndent">Banana := {"Color": "Yellow", "Taste": "Delicious", "Price": 3}</pre>
-        <p>This will let you start of by defining what is sometimes called an "associative array". An associative array is a collection of data where each item has a name. In this example, the value <code>"Yellow"</code> is stored in the object key <code>"Color"</code>. Also, the value <code>3</code> is stored in the object key <code>"Price"</code>.</p>
+        <pre class="NoIndent">Banana := {Color: "Yellow", Taste: "Delicious", Price: 3}</pre>
+        <p>This will let you start of by defining what is sometimes called an "associative array". An associative array is a collection of data where each item has a name. In this example, the value <code>"Yellow"</code> is stored in the object key <code>Color</code>. Also, the value <code>3</code> is stored in the object key <code>Price</code>.</p>
     </dd>
     <dt>Array constructor</dt>
     <dd>


### PR DESCRIPTION
v2 requires object literal for the Key in the Brace Syntax aka Associative Array. The doc currently displays a String for a Key which would always produce an error when attempted in v2 so I just removed the quotes on the Keys in the doc.