### PR TITLE
Update Send.htm

### DIFF
--- a/docs/commands/Send.htm
+++ b/docs/commands/Send.htm
@@ -232,7 +232,7 @@
   </tr>
   <tr class="sep_below">
     <td>{Control down} or {Ctrl down}</td>
-    <td>Holds <kbd>Ctrl</kbd> down until {Ctrl up} is sent. To hold down the left or right key instead, use {RCtrl down} and {RCtrl up}.</td>
+    <td>Holds <kbd>Ctrl</kbd> down until {Ctrl up} is sent. To hold down the left or right key instead, use {LCtrl down} and {RCtrl down}.</td>
   </tr>
   <tr>
     <td>{Alt}</td>
@@ -248,7 +248,7 @@
   </tr>
   <tr class="sep_below">
     <td>{Alt down}</td>
-    <td>Holds <kbd>Alt</kbd> down until {Alt up} is sent. To hold down the left or right key instead, use {RAlt down} and {RAlt up}.</td>
+    <td>Holds <kbd>Alt</kbd> down until {Alt up} is sent. To hold down the left or right key instead, use {LAlt down} and {RAlt down}.</td>
   </tr>
   <tr>
     <td>{Shift}</td>
@@ -264,7 +264,7 @@
   </tr>
   <tr class="sep_below">
     <td>{Shift down}</td>
-    <td>Holds <kbd>Shift</kbd> down until {Shift up} is sent. To hold down the left or right key instead, use {RShift down} and {RShift up}.</td>
+    <td>Holds <kbd>Shift</kbd> down until {Shift up} is sent. To hold down the left or right key instead, use {LShift down} and {RShift down}.</td>
   </tr>
   <tr>
     <td>{LWin}</td>


### PR DESCRIPTION
I don't know if this was intentional, but I find the Descriptions of these 3 keys confusing:

> {Control down} or {Ctrl down}		Holds Ctrl down until {Ctrl up} is sent. To hold down the left or right key instead, use {RCtrl down} and {RCtrl up}.

> {Alt down}		Holds Alt down until {Alt up} is sent. To hold down the left or right key instead, use {RAlt down} and {RAlt up}.

> {Shift down}		Holds Shift down until {Shift up} is sent. To hold down the left or right key instead, use {RShift down} and {RShift up}.

This text implies, for example, that using {RShift down} and {RShift up} has something to do with "holding down the left ... key instead" which it certainly does not.

I propose to remove the references to {... up} in these descriptions, and instead use the relevant L-key-variant names.