### PR TITLE
Add examples with Add[Control]

### DIFF
--- a/docs/commands/GuiControls.htm
+++ b/docs/commands/GuiControls.htm
@@ -34,7 +34,9 @@
 <h2 id="Text">Text</h2>
 <p>Description: A region containing borderless text that the user cannot edit. Often used to label other controls.</p>
 <p>For example:</p>
-<pre>MyGui.Add("Text",, "Please enter your name:")</pre>
+<pre>MyGui.Add("Text",, "Please enter your name:")
+<em>; or</em>
+MyGui.AddText(, "Please enter your name:")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_text.png" alt="Text" />
 <p>In this case, the last parameter is the string to display. It may contain linefeeds (`n) to start new lines. In addition, a single long line can be broken up into several shorter ones by means of a <a href="../Scripts.htm#continuation">continuation section</a>.</p>
@@ -64,7 +66,9 @@ MyGui.Add("Edit")</pre>
 <h2 id="Edit">Edit</h2>
 <p>Description: An area where free-form text can be typed by the user.</p>
 <p>For example:</p>
-<pre>MyGui.Add("Edit", "r9 vMyEdit w135", "Text to appear inside the edit control (omit this parameter to start off empty).")</pre>
+<pre>MyGui.Add("Edit", "r9 vMyEdit w135", "Text to appear inside the edit control (omit this parameter to start off empty).")
+<em>; or</em>
+MyGui.AddEdit("r9 vMyEdit w135", "Text to appear inside the edit control (omit this parameter to start off empty).")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_edit.png" alt="Edit" />
 <p>The control will be multi-line if it has more than one row of text. For example, specifying <code>r3</code> in <em>Options</em> will create a 3-line edit control with the following default properties: a vertical scroll bar, word-wrapping enabled, and <kbd>Enter</kbd> captured as part of the input rather than triggering the window's <a href="#DefaultButton">default button</a>.</p>
@@ -96,7 +100,9 @@ MyEdit.Value := FileRead("C:\My File.txt")</pre>
 <p>Description: A pair of arrow buttons that the user can click to increase or decrease a value. By default, an UpDown control automatically snaps onto the previously added control. This previous control is known as the UpDown's <em>buddy control</em>. The most common example is a "spinner", which is an UpDown attached to an <a href="#Edit">Edit control</a>.</p>
 <p>For example:</p>
 <pre>MyGui.Add("Edit")
-MyGui.Add("UpDown", "vMyUpDown Range1-10", 5)</pre>
+MyGui.Add("UpDown", "vMyUpDown Range1-10", 5)
+<em>; or</em>
+MyGui.AddUpDown("vMyUpDown Range1-10", 5)</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_updown.png" alt="UpDown" />
 <p>In the example above, the Edit control is the UpDown's buddy control. Whenever the user presses one of the arrow buttons, the number in the Edit control is automatically increased or decreased.</p>
@@ -121,7 +127,9 @@ MyGui.Add("UpDown", "vMyUpDown Range1-10", 5)</pre>
 <span id="Pic"></span><h2 id="Picture">Picture (or Pic)</h2>
 <p>Description: An area containing an image (see last two paragraphs for supported file types). The last parameter is the filename of the image, which is assumed to be in <a href="../Variables.htm#WorkingDir">A_WorkingDir</a> if an absolute path isn't specified.</p>
 <p>For example:</p>
-<pre>MyGui.Add("Picture", "w300 h-1", "C:\My Pictures\Company Logo.gif")</pre>
+<pre>MyGui.Add("Picture", "w300 h-1", "C:\My Pictures\Company Logo.gif")
+<em>; or</em>
+MyGui.AddPicture("w300 h-1", "C:\My Pictures\Company Logo.gif")</pre>
 <p>To retain the image's actual width and/or height, omit the W and/or H options. Otherwise, the image is scaled to the specified width and/or height (this width and height also determines which icon to load from a multi-icon .ICO file). To shrink or enlarge the image while preserving its aspect ratio, specify -1 for one of the dimensions and a positive number for the other. For example, specifying <code>w200 h-1</code> would make the image 200 pixels wide and cause its height to be set automatically. If the picture cannot be loaded or displayed (e.g. file not found), an error is thrown and the control is not added.</p>
 <p>Picture controls support the <a href="../objects/GuiOnEvent.htm#Click">Click</a> and <a href="../objects/GuiOnEvent.htm#DoubleClick">DoubleClick</a> events, with the same <a href="#SS_NOTIFY">caveat</a> as Text controls.</p>
 <p>To use a picture as a background for other controls, the picture should normally be added prior to those controls. However, if those controls are input-capable and the picture has the <a href="#SS_NOTIFY">SS_NOTIFY style</a> (which may be added automatically by <a href="../objects/GuiOnEvent.htm">OnEvent</a>), create the picture after the other controls and include <code>0x4000000</code> (which is WS_CLIPSIBLINGS) in the picture's <em>Options</em>. This trick also allows a picture to be the background behind a <a href="#Tab">Tab control</a> or <a href="ListView.htm">ListView</a>.</p>
@@ -140,6 +148,8 @@ MyGui.Show</pre>
 <p>Description: A pushbutton, which can be pressed to trigger an action.  In this case, the last parameter is the name of the button (shown on the button itself), which may include linefeeds (`n) to start new lines.</p>
 <p>For example:</p>
 <pre>MyBtn := MyGui.Add("Button", "Default w80", "OK")
+<em>; or</em>
+MyBtn := MyGui.AddButton("Default w80", "OK")
 MyBtn.OnEvent("Click", MyBtn_Click)  <em>; Call MyBtn_Click when clicked.</em>
 </pre>
 <p>Appearance:</p>
@@ -156,7 +166,9 @@ MyBtn.OnEvent("Click", MyBtn_Click)  <em>; Call MyBtn_Click when clicked.</em>
 <h2 id="Checkbox">Checkbox</h2>
 <p>Description: A small box that can be checked or unchecked to represent On/Off, Yes/No, etc.</p>
 <p>For example:</p>
-<pre>MyGui.Add("CheckBox", "vShipToBillingAddress", "Ship to billing address?")</pre>
+<pre>MyGui.Add("CheckBox", "vShipToBillingAddress", "Ship to billing address?")
+<em>; or</em>
+MyGui.AddCheckBox("vShipToBillingAddress", "Ship to billing address?")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_check.png" alt="Checkbox" />
 <p>The last parameter is a label displayed next to the box, which is typically used as a prompt or description of what the checkbox does. It may include linefeeds (`n) to start new lines. If a width (W) is specified in <em>Options</em> but no <a href="../objects/Gui.htm#R">rows (R)</a> or height (H), the control's text will be word-wrapped as needed, and the control's height will be set automatically.</p>
@@ -169,7 +181,9 @@ MyBtn.OnEvent("Click", MyBtn_Click)  <em>; Call MyBtn_Click when clicked.</em>
 <h2 id="Radio">Radio</h2>
 <p>Description: A radio button is a small empty circle that can be checked (on) or unchecked (off).</p>
 <p>For example:</p>
-<pre>MyGui.Add("Radio", "vMyRadioGroup", "Wait for all items to be in stock before shipping.")</pre>
+<pre>MyGui.Add("Radio", "vMyRadioGroup", "Wait for all items to be in stock before shipping.")
+<em>; or</em>
+MyGui.AddRadio("vMyRadioGroup", "Wait for all items to be in stock before shipping.")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_radio.png" alt="Radio" />
 <p>These controls usually appear in <em>radio groups</em>, each of which contains two or more radio buttons. When the user clicks a radio button to turn it on, any others in its radio group are turned off automatically (the user may also navigate inside a group with the arrow keys). A radio group is created automatically around all consecutively added radio buttons. To start a new group, specify the word <strong>Group</strong> in the <em>Options</em> of the first button of the new group -- or simply add a non-radio control in between, since that automatically starts a new group.</p>
@@ -184,7 +198,8 @@ MyBtn.OnEvent("Click", MyBtn_Click)  <em>; Call MyBtn_Click when clicked.</em>
 <p>Description: A list of choices that is displayed in response to pressing a small button.  In this case, the last parameter of <a href="../objects/Gui.htm#Add">MyGui.Add</a> is an <a href="../objects/Array.htm">Array</a> like <code>["Choice1","Choice2","Choice3"]</code>.</p>
 <p>For example:</p>
 <pre>MyGui.Add("DropDownList", "vColorChoice", ["Black","White","Red","Green","Blue"])
-</pre>
+<em>; or</em>
+MyGui.AddDropDownList("vColorChoice", ["Black","White","Red","Green","Blue"])</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_ddl.png" alt="DDL" />
 <p>To have one of the items pre-selected when the window first appears, include in <em>Options</em> the word <strong>Choose</strong> followed immediately by the number of an item to be pre-selected. For example, <code>Choose5</code> would pre-select the fifth item (as with other options, it can also be a variable such as <code>"Choose" Var</code>). After the control is created, use <a href="../objects/GuiControl.htm#Value">GuiCtrl.Value</a>, <a href="../objects/GuiControl.htm#Text">GuiCtrl.Text</a> or <a href="../objects/GuiControl.htm#Choose">GuiCtrl.Choose</a> to change the selection, and <a href="../objects/GuiControl.htm#Add">GuiCtrl.Add</a> or <a href="../objects/GuiControl.htm#Delete">GuiCtrl.Delete</a> to add or remove entries from the list.</p>
@@ -204,7 +219,8 @@ MyGui.Show("h70")</pre>
 <p>Description: Same as DropDownList but also permits free-form text to be entered as an alternative to picking an item from the list.</p>
 <p>For example:</p>
 <pre>MyGui.Add("ComboBox", "vColorChoice", ["Red","Green","Blue","Black","White"])
-</pre>
+<em>; or</em>
+MyGui.AddComboBox("vColorChoice", ["Red","Green","Blue","Black","White"])</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_combo.png" alt="ComboBox" />
 <p>In addition to allowing all the same options as DropDownList above, the word <strong>Limit</strong> may be included in <em>Options</em> to restrict the user's input to the visible width of the ComboBox's edit field. Also, the word <strong>Simple</strong> may be specified to make the ComboBox behave as though it is an Edit field with a ListBox beneath it.</p>
@@ -215,7 +231,8 @@ MyGui.Show("h70")</pre>
 <p>Description: A relatively tall box containing a list of choices that can be selected. In this case, the last parameter of <a href="../objects/Gui.htm#Add">MyGui.Add</a> is an <a href="../objects/Array.htm">Array</a> like <code>["Choice1","Choice2","Choice3"]</code>.</p>
 <p>For example:</p>
 <pre>MyGui.Add("ListBox", "r5 vColorChoice", ["Red","Green","Blue","Black","White"])
-</pre>
+<em>; or</em>
+MyGui.AddListBox("r5 vColorChoice", ["Red","Green","Blue","Black","White"])</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_list.png" alt="ListBox" />
 <p id="ChooseLB">To have one of the items pre-selected when the window first appears, include in <em>Options</em> the word <strong>Choose</strong> followed immediately by the number of an item to be pre-selected. For example, <code>Choose5</code> would pre-select the fifth item. To have multiple items pre-selected, use <a href="../objects/GuiControl.htm#Choose">GuiCtrl.Choose</a> multiple times (requires the <a href="#ListBoxMulti">Multi</a> option). After the control is created, use <a href="../objects/GuiControl.htm#Value">GuiCtrl.Value</a>, <a href="../objects/GuiControl.htm#Text">GuiCtrl.Text</a> or <a href="../objects/GuiControl.htm#Choose">GuiCtrl.Choose</a> to change the selection, and <a href="../objects/GuiControl.htm#Add">GuiCtrl.Add</a> or <a href="../objects/GuiControl.htm#Delete">GuiCtrl.Delete</a> to add or remove entries from the list.</p>
@@ -244,6 +261,8 @@ MyGui.Show("h70")</pre>
 <p>Description: A text control that can contain links similar to those found in a web browser. Within the control's text, enclose the link text within <code>&lt;A&gt;</code> and <code>&lt;/A&gt;</code> to create a clickable link. Although this looks like HTML, Link controls only support the opening <code>&lt;A&gt;</code> tag (optionally with an ID and/or HREF attribute) and closing <code>&lt;/A&gt;</code> tag.</p>
 <p>For example:</p>
 <pre>MyGui.Add("Link",, 'This is a &lt;a href="https://www.autohotkey.com"&gt;link&lt;/a&gt;')
+<em>; or</em>
+MyGui.AddLink(, 'This is a &lt;a href="https://www.autohotkey.com"&gt;link&lt;/a&gt;')
 MyGui.Add("Link",, 'Links may be used anywhere in the text like &lt;a id="A"&gt;this&lt;/a&gt; or &lt;a id="B"&gt;that&lt;/a&gt;')</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_link.png" alt="Link" />
@@ -264,7 +283,9 @@ MyGui.Show()</pre>
 <h2 id="Hotkey">Hotkey</h2>
 <p>Description: A box that looks like a single-line edit control but instead accepts a keyboard combination pressed by the user. For example, if the user presses <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>C</kbd> on an English keyboard layout, the box would display "Ctrl + Alt + C".</p>
 <p>For example:</p>
-<pre>MyGui.Add("Hotkey", "vChosenHotkey")</pre>
+<pre>MyGui.Add("Hotkey", "vChosenHotkey")
+<em>; or</em>
+MyGui.AddHotkey("vChosenHotkey")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_hotkey.png" alt="Hotkey" />
 <p><a href="../objects/GuiControl.htm#Value">GuiCtrl.Value</a> returns the control's hotkey modifiers and name, which are compatible with the <a href="Hotkey.htm">Hotkey</a> function. Examples: <code>^!C</code>, <code>+!Home</code>, <code>+^Down</code>, <code>^Numpad1</code>, <code>!NumpadEnd</code>. If there is no hotkey in the control, the value is blank.</p>
@@ -290,7 +311,8 @@ MyGui.Show()</pre>
 <p>Description: A box that looks like a single-line edit control but instead accepts a date and/or time. A drop-down calendar is also provided.</p>
 <p>For example:</p>
 <pre>MyGui.Add("DateTime", "vMyDateTime", "LongDate")
-</pre>
+<em>; or</em>
+MyGui.AddDateTime("vMyDateTime", "LongDate")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_datetime.png" alt="DateTime" />
 <p>The last parameter is a format string, as described below.</p>
@@ -329,7 +351,9 @@ MyGui.Show()</pre>
 <h2 id="MonthCal">MonthCal</h2>
 <p>Description: A tall and wide control that displays all the days of the month in calendar format. The user may select a single date or a range of dates.</p>
 <p>For example:</p>
-<pre>MyGui.Add("MonthCal", "vMyCalendar")</pre>
+<pre>MyGui.Add("MonthCal", "vMyCalendar")
+<em>; or</em>
+MyGui.AddMonthCal("vMyCalendar")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_monthcal.png" alt="MonthCal" />
 <p>To have a date other than today pre-selected, specify it as the third parameter in YYYYMMDD format (e.g. <code>20050531</code>). A range of dates may also be pre-selected by including a dash between two dates (e.g. <code>"20050525-20050531"</code>).</p>
@@ -352,7 +376,9 @@ MyGui.Show()</pre>
 <h2 id="Slider">Slider</h2>
 <p>Description: A sliding bar that the user can move along a vertical or horizontal track. The standard volume control in the taskbar's tray is an example of a slider.</p>
 <p>For example:</p>
-<pre>MyGui.Add("Slider", "vMySlider", 50)</pre>
+<pre>MyGui.Add("Slider", "vMySlider", 50)
+<em>; or</em>
+MyGui.AddSlider("vMySlider", 50)</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_slider.png" alt="Slider" />
 <p>Specify the starting position of the slider as the last parameter. If the last parameter  is omitted, the slider starts off at 0 or the number in the allowable range that is closest to 0.</p>
@@ -404,7 +430,9 @@ MyGui.Show()</pre>
 <h2 id="Progress">Progress</h2>
 <p>Description: A dual-color bar typically used to indicate how much progress has been made toward the completion of an operation.</p>
 <p>For example:</p>
-<pre>MyGui.Add("Progress", "w200 h20 cBlue vMyProgress", 75)</pre>
+<pre>MyGui.Add("Progress", "w200 h20 cBlue vMyProgress", 75)
+<em>; or</em>
+MyGui.AddProgress("w200 h20 cBlue vMyProgress", 75)</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_progress.png" alt="Progress" />
 <p>Specify the starting position of the bar as the third parameter (if omitted, the bar starts off at 0 or the number in the allowable range that is closest to 0). To later change the position of the bar, follow these examples, all of which operate upon a progress bar whose <a href="../objects/GuiControl.htm#Name">Name</a> is MyProgress:</p>
@@ -424,7 +452,8 @@ MyGui["MyProgress"].Value := 50  <em>; Set the current position to 50.</em></pre
 <p>Description: A rectangular border/frame, often used around other controls to indicate they are related. In this case, the last parameter is the title of the box, which if present is displayed at its upper-left edge.</p>
 <p>For example:</p>
 <pre>MyGui.Add("GroupBox", "w200 h100", "Geographic Criteria")
-</pre>
+<em>; or</em>
+MyGui.AddGroupBox("w200 h100", "Geographic Criteria")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_group.png" alt="GroupBox" />
 <p>By default, a GroupBox's title may have only one line of text. This can be overridden by specifying <code>Wrap</code> in <em>Options</em>.</p>
@@ -439,7 +468,9 @@ MyGui["MyProgress"].Value := 50  <em>; Set the current position to 50.</em></pre
   <li><strong>Tab</strong>: Retained for backward compatibility because of <a href="#Tab_vs">differences in behavior</a> between Tab2/Tab3 and Tab.</li>
 </ul>
 <p>For example:</p>
-<pre>MyGui.Add("Tab3",, ["General","View","Settings"])</pre>
+<pre>MyGui.Add("Tab3",, ["General","View","Settings"])
+<em>; or</em>
+MyGui.AddTab3(, ["General","View","Settings"])</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_tab.png" alt="Tab" />
 <p id="ChooseTab">The last parameter above is an <a href="../objects/Array.htm">Array</a> of tab names. To have one of the tabs pre-selected when the window first appears, include in <em>Options</em> the word <strong>Choose</strong> followed immediately by the number of a tab to be pre-selected. For example, <code>Choose5</code> would pre-select the fifth tab (as with other options, it can also be a variable such as <code>"Choose" Var</code>). After the control is created, use <a href="../objects/GuiControl.htm#Value">Value</a>, <a href="../objects/GuiControl.htm#Text">Text</a> or <a href="../objects/GuiControl.htm#Choose">Choose</a> to change the selected tab, and <a href="../objects/GuiControl.htm#Add">Add</a> or <a href="../objects/GuiControl.htm#Delete">Delete</a> to add or remove tabs.</p>
@@ -502,6 +533,8 @@ Tab.UseTab("Name", true)  <em>; Same as above but requires exact match (not case
 <p>Description: A row of text and/or icons attached to the bottom of a window, which is typically used to report changing conditions.</p>
 <p>For example:</p>
 <pre>SB := MyGui.Add("StatusBar",, "Bar's starting text (omit to start off empty).")
+<em>; or</em>
+SB := MyGui.AddStatusBar(, "Bar's starting text (omit to start off empty).")
 SB.SetText("There are " . RowCount . " rows selected.")</pre>
 <p>Appearance:</p>
 <img src="../static/ctrl_status.png" alt="StatusBar" />


### PR DESCRIPTION
This change would allow searching for `Add[Control]` in the help file and land on the relevant page.

At this moment searching for `AddButton` would return no pages and some other controls like `AddText` would land on pages that are less relevant than this one.