### PR TITLE
ControlFocus remark

### DIFF
--- a/docs/lib/ControlFocus.htm
+++ b/docs/lib/ControlFocus.htm
@@ -44,6 +44,10 @@
 <p>To improve reliability, a delay is done automatically after every use of this command. That delay can be changed via <a href="SetControlDelay.htm">SetControlDelay</a>.</p>
 <p>To discover the ClassNN or HWND of the control that the mouse is currently hovering over, use <a href="MouseGetPos.htm">MouseGetPos</a>.</p>
 <p>Window titles and text are case sensitive. Hidden windows are not detected unless <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a> has been turned on.</p>
+<p>Setting keyboard focus to target control has different result, then switching focus to same control using <kbd>Tab</kbd> key on keyboard. By default, <em>Button</em> control with keyboard focus can be pressed by <kbd>Space</kbd> key, <em>Edit</em> control has input caret in it. Switching keyboard focus with <kbd>Tab</kbd> key to <em>Button</em> control (manually or by <a href="Send.htm">Send</a> command) additionally changes behavior of <kbd>Enter</kbd> key (it begins point out to focused <em>Button</em>, not to <a href="GuiControls.htm#DefaultButton">default</a> <em>Button</em> in window, if its present); to <em>Edit</em> control - additionally selects all text in it. <em>Tab</em> behavior can be achieved by sending message to window via <a href="../misc/SendMessage.htm">SendMessage</a> command like in this example:</p>
+<pre>hWnd := WinExist("A") ; Get HWND of active window
+ControlGet, hWndControl, Hwnd,, Button1, ahk_id %hWnd% ; Get HWND of first button
+SendMessage, 0x0028, hWndControl, True,, ahk_id %hWnd% ; 0x0028 is WM_NEXTDLGCTL</pre>
 
 <h2 id="Related">Related</h2>
 <p><a href="SetControlDelay.htm">SetControlDelay</a>, <a href="ControlGetFocus.htm">ControlGetFocus</a>, <a href="Control.htm">Control</a>, <a href="ControlGet.htm">ControlGet</a>, <a href="ControlMove.htm">ControlMove</a>, <a href="ControlGetPos.htm">ControlGetPos</a>, <a href="ControlClick.htm">ControlClick</a>, <a href="ControlGetText.htm">ControlGetText</a>, <a href="ControlSetText.htm">ControlSetText</a>, <a href="ControlSend.htm">ControlSend</a></p>

--- a/docs/lib/GuiControl.htm
+++ b/docs/lib/GuiControl.htm
@@ -89,7 +89,7 @@ GuiControl, Move, MyEdit, % "x" VarX+10 "y" VarY+5 "w" VarW*2 "h" VarH*1.5 <em>;
 <h3 id="Focus">Focus</h3>
 <p>Sets keyboard focus to the control.</p>
 <pre class="Syntax"><span class="func">GuiControl</span>, Focus, ControlID</pre>
-<p>To be effective, the window generally must not be minimized or hidden.</p>
+<p>To be effective, the window generally must not be minimized or hidden. Additionally see example with sending message to window in <a href="ControlFocus.htm#Remarks">remarks</a> of ControlFocus command.</p>
 
 <div id="EnableDisable">
   <h3 id="Disable">Disable</h3>


### PR DESCRIPTION
Explanation in canges. Below is example to show it and test proposed example.

```AutoHotKey
#NoEnv
#SingleInstance
Gui New, HWndHGui +LastFound
Gui Add, Text,,
(LTrim
    F1: GuiControl Focus Button2
    F2: GuiControl Focus Edit2
    F3: ControlFocus Button2
    F4: ControlFocus Edit2
    F5: WM_NEXTDLGCTL (WS_TABSTOP) Focus Button2
    F6: WM_NEXTDLGCTL (WS_TABSTOP) Focus Edit2
    F7: Send {Tab}
    F8: Test proposed example for Pull Request
    F9: Reload
    You may need reload script to see difference
)
Gui Add, Button, gButton, Button1
Gui Add, Edit,, Text1
Gui Add, Button, gButton HWndHButton2, Button2
Gui Add, Edit, HWndHEdit2, Text2
Gui Add, Button, gButton Default, Default
Gui Show
Return

GuiEscape:
GuiClose:
ExitApp

Button:
    MsgBox % A_GuiControl
Return

F1:: GuiControl, Focus, % hButton2
F2:: GuiControl, Focus, % hEdit2
F3:: ControlFocus,, ahk_id %hButton2%
F4:: ControlFocus,, ahk_id %hEdit2%
F5:: SendMessage, 0x0028, hButton2, True,, ahk_id %hGui%
F6:: SendMessage, 0x0028, hEdit2, True,, ahk_id %hGui%
F7:: Send {Tab}
F9:: Reload
F8:: ;Example
    hWnd := WinExist("A") ; Get HWND of active window
    ControlGet, hWndControl, Hwnd,, Button2, ahk_id %hWnd% ; Get HWND of second button
    SendMessage, 0x0028, hWndControl, True,, ahk_id %hWnd% ; 0x0028 is WM_NEXTDLGCTL
Return
```