### PR TITLE
Add @Ahk2Exe-Set example

### DIFF
--- a/docs/misc/Ahk2ExeDirectives.htm
+++ b/docs/misc/Ahk2ExeDirectives.htm
@@ -362,6 +362,8 @@ MsgBox This message appears in both the compiled and uncompiled script
   <dt>Value</dt>
   <dd>The value to set the property to.</dd>
 </dl>
+<p><strong>Example 1:</strong> This example changes the compiled script's displayed name in Task Manager:</p>
+<pre><em>;@Ahk2Exe-Set FileDescription, MyScriptName</em></pre>
 
 <h3 id="UpdateManifest">UpdateManifest</h3>
 <p>Changes details in the .exe's manifest. This directive is for specialised use only.</p>

--- a/docs/misc/Ahk2ExeDirectives.htm
+++ b/docs/misc/Ahk2ExeDirectives.htm
@@ -306,7 +306,7 @@ MsgBox This message appears in both the compiled and uncompiled script
       </tr>
       <tr>
         <td>Description</td>
-        <td>Changes the file description.</td>
+        <td>Changes the file description. On Windows 8 and above, this also changes the script's name in Task Manager under "Processes".</td>
       </tr>
       <tr>
         <td>FileVersion</td>
@@ -362,8 +362,6 @@ MsgBox This message appears in both the compiled and uncompiled script
   <dt>Value</dt>
   <dd>The value to set the property to.</dd>
 </dl>
-<p><strong>Example 1:</strong> This example changes the compiled script's displayed name in Task Manager:</p>
-<pre><em>;@Ahk2Exe-Set FileDescription, MyScriptName</em></pre>
 
 <h3 id="UpdateManifest">UpdateManifest</h3>
 <p>Changes details in the .exe's manifest. This directive is for specialised use only.</p>


### PR DESCRIPTION
I think this example is particularly helpful, since it's not supported by `;@Ahk2Exe-SetProp`. The example changes the compiled script's displayed name in Task Manager.

From https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource

FileDescription - File description to be presented to users. This string may be displayed in a list box when the user is choosing files to install—for example, Keyboard Driver for AT-Style Keyboards. This string is required.

Example demonstration:
```
;@Ahk2Exe-Set FileDescription, MyTestApp
#Persistent
```
Result:
![image](https://user-images.githubusercontent.com/72886672/209463985-1f2529fb-ee5e-4087-8807-d9f58687d9ce.png)
