### PR TITLE
v2: Fix sample script Edit

### DIFF
--- a/docs/lib/Edit.htm
+++ b/docs/lib/Edit.htm
@@ -34,7 +34,7 @@
 <pre>Editor := FileSelect(2,, "Select your editor", "Programs (*.exe)")
 if Editor = ""
     ExitApp
-RegWrite "REG_SZ", "HKCR\AutoHotkeyScript\Shell\Edit\Command",, Format('"{1}" "%1"', Editor)</pre>
+RegWrite Format('"{1}" "%1"', Editor), "REG_SZ", "HKCR\AutoHotkeyScript\Shell\Edit\Command"</pre>
 </div>
 
 <h2 id="Editors">Editors with AutoHotkey Support</h2>


### PR DESCRIPTION
RegWrite function call was still in v1 format causing a syntax error.