### PR TITLE
Use %L instead of %1 in sample script

### DIFF
--- a/docs/lib/Edit.htm
+++ b/docs/lib/Edit.htm
@@ -34,7 +34,7 @@
 <pre>Editor := FileSelect(2,, "Select your editor", "Programs (*.exe)")
 if Editor = ""
     ExitApp
-RegWrite Format('"{1}" "%1"', Editor), "REG_SZ", "HKCR\AutoHotkeyScript\Shell\Edit\Command"</pre>
+RegWrite Format('"{1}" "%L"', Editor), "REG_SZ", "HKCR\AutoHotkeyScript\Shell\Edit\Command"</pre>
 </div>
 
 <h2 id="Editors">Editors with AutoHotkey Support</h2>


### PR DESCRIPTION
The use of %L to always use long filenames is recommended nowadays for this setting.
Editor settings in AutoHotkey Dash also adds %L by default when using the browse button to select an editor.