### PR TITLE
escape quotes in quoted strings

### DIFF
--- a/docs/static/source/build_search.ahk
+++ b/docs/static/source/build_search.ahk
@@ -161,7 +161,7 @@ ScanFiles()
     
     s .= "var SearchTitles = ["
     for i, t in stitles
-        s .= Format('"{1}",', t)
+        s .= Format('"{1}",', StrReplace(t, '"', '\"'))
     s := SubStr(s,1,-1) "]`n`n"
     
     s .= "


### PR DESCRIPTION
Recently `" (quoted text)` was added to the Help Index.
The tool build_search.ahk didn't properly handle quotes in index entries, resulting in a faulty data_search.js file.