### PR TITLE
Update LoopFiles.htm

### DIFF
--- a/docs/lib/LoopFiles.htm
+++ b/docs/lib/LoopFiles.htm
@@ -133,6 +133,8 @@ Loop Parse, FileList, "`n"
 <p>See <a href="Loop.htm">Loop</a> for information about <a href="Block.htm">Blocks</a>, <a href="Break.htm">Break</a>, <a href="Continue.htm">Continue</a>, and the A_Index variable (which exists in every type of loop).</p>
 <p>The loop may optionally be followed by an <a href="Else.htm">Else</a> statement, which is executed if no matching files or directories were found (i.e. the loop had zero iterations).</p>
 
+The functions <a href="FileGetAttrib.htm">FileGetAttrib</a>, <a href="FileGetSize.htm">FileGetSize</a>, <a href="FileGetTime.htm">FileGetTime</a>, <a href="FileGetVersion.htm">FileGetVersion</a>, <a href="FileSetAttrib.htm">FileSetAttrib</a>, and <a href="FileSetTime.htm">FileSetTime</a> can be used in a file-loop without their Filename/FilePattern parameter.
+
 <h2 id="Related">Related</h2>
 <p><a href="Loop.htm">Loop</a>, <a href="Break.htm">Break</a>, <a href="Continue.htm">Continue</a>, <a href="Block.htm">Blocks</a>, <a href="SplitPath.htm">SplitPath</a>, <a href="FileSetAttrib.htm">FileSetAttrib</a>, <a href="FileSetTime.htm">FileSetTime</a></p>
 

--- a/docs/lib/LoopFiles.htm
+++ b/docs/lib/LoopFiles.htm
@@ -132,8 +132,7 @@ Loop Parse, FileList, "`n"
 <p id="otb">The One True Brace (OTB) style may optionally be used, which allows the open-brace to appear on the same line rather than underneath. For example: <code>Loop Files "*.txt", "R" {</code>.</p>
 <p>See <a href="Loop.htm">Loop</a> for information about <a href="Block.htm">Blocks</a>, <a href="Break.htm">Break</a>, <a href="Continue.htm">Continue</a>, and the A_Index variable (which exists in every type of loop).</p>
 <p>The loop may optionally be followed by an <a href="Else.htm">Else</a> statement, which is executed if no matching files or directories were found (i.e. the loop had zero iterations).</p>
-
-The functions <a href="FileGetAttrib.htm">FileGetAttrib</a>, <a href="FileGetSize.htm">FileGetSize</a>, <a href="FileGetTime.htm">FileGetTime</a>, <a href="FileGetVersion.htm">FileGetVersion</a>, <a href="FileSetAttrib.htm">FileSetAttrib</a>, and <a href="FileSetTime.htm">FileSetTime</a> can be used in a file-loop without their Filename/FilePattern parameter.
+<p>The functions <a href="FileGetAttrib.htm">FileGetAttrib</a>, <a href="FileGetSize.htm">FileGetSize</a>, <a href="FileGetTime.htm">FileGetTime</a>, <a href="FileGetVersion.htm">FileGetVersion</a>, <a href="FileSetAttrib.htm">FileSetAttrib</a>, and <a href="FileSetTime.htm">FileSetTime</a> can be used in a file-loop without their Filename/FilePattern parameter.</p>
 
 <h2 id="Related">Related</h2>
 <p><a href="Loop.htm">Loop</a>, <a href="Break.htm">Break</a>, <a href="Continue.htm">Continue</a>, <a href="Block.htm">Blocks</a>, <a href="SplitPath.htm">SplitPath</a>, <a href="FileSetAttrib.htm">FileSetAttrib</a>, <a href="FileSetTime.htm">FileSetTime</a></p>


### PR DESCRIPTION
Added references to functions that can be used in a file-loop without their Filename/FilePattern parameter to the bottom of the [Remarks](https://www.autohotkey.com/docs/v2/lib/LoopFiles.htm#Remarks) section.