### PR TITLE
Update GuiControl.htm

### DIFF
--- a/docs/lib/GuiControl.htm
+++ b/docs/lib/GuiControl.htm
@@ -118,7 +118,7 @@ ListBox.Choose(0)  <em>; Deselect all items.</em></pre>
 <div class="methodShort" id="GetPos">
 <h3>GetPos</h3>
 <p>Retrieves the position and size of the control.</p>
-<pre class="Syntax">GuiCtrl.<span class="func">GetPos</span>(<span class="optional">X, Y, Width, Height</span>)</pre>
+<pre class="Syntax">GuiCtrl.<span class="func">GetPos</span>(<span class="optional">&amp;X, &amp;Y, &amp;Width, &amp;Height</span>)</pre>
 <p>Each parameter should be a <a href="../Concepts.htm#variable-references">reference</a> to the variable in which to store the respective coordinate. The position is relative to the GUI window's client area, which is the area not including title bar, menu bar, and borders.</p>
 <p>Unlike <a href="ControlGetPos.htm">ControlGetPos</a>, this method applies <a href="Gui.htm#DPIScale">DPI scaling</a> to the returned coordinates (unless the <code>-DPIScale</code> option was used).</p>
 <p>Example:</p>


### PR DESCRIPTION
Added reference operator (&) for consistency with other parts of the documentation. For example, see [MyGui.GetPos](https://www.autohotkey.com/docs/v2/lib/Gui.htm#GetPos).