### PR TITLE
Add known limitation to Gui.Call() method

### DIFF
--- a/docs/lib/Gui.htm
+++ b/docs/lib/Gui.htm
@@ -78,9 +78,11 @@
 <p>Creates and returns a new Gui object.</p>
 <pre class="Syntax">MyGui := <span class="func">Gui</span>(<span class="optional">Options, Title, EventObj</span>)</pre>
 <dl>
-  <dt>Options</dt><dd>
+  <dt>Options</dt>
+  <dd>
     <p>Type: <a href="../Concepts.htm#strings">String</a></p>
     <p>This parameter can contain any of the options supported by <a href="#Opt">Gui.Opt</a>.</p>
+    <p><strong>Known limitation:</strong> the <code>+Parent</code> property might fail when creating the window if the parent window is external, due to differences on how styles are applied.</p>
   </dd>
   <dt>Title</dt><dd>
     <p>Type: <a href="../Concepts.htm#strings">String</a></p>


### PR DESCRIPTION
As discussed in [this thread](https://www.autohotkey.com/boards/viewtopic.php?p=525546#p525546) there are some limitations that cannot be properly documented but that is good to have at least a warning about it when creating a GUI that is a child of an external window.