### PR TITLE
Add a table with message number ranges for Post/Send/OnMessage functions

### DIFF
--- a/docs/misc/SendMessageList.htm
+++ b/docs/misc/SendMessageList.htm
@@ -10,6 +10,21 @@
 </head>
 
 <body>
+<h1>Ranges of Windows Message numbers</h1>
+<p>Below is a summary table of values for the <em>MsgNumber</em> parameter of <a href="../lib/PostMessage.htm">PostMessage</a>, <a href="../lib/SendMessage.htm">SendMessage</a>, and <a href="../lib/OnMessage.htm">OnMessage</a>.</p>
+<table><thead><tr><th>Min<br/>0 x Hex</th><th>Max<br/>0 x Hex</th><th>Meaning</th></tr></thead>
+<tbody>
+<tr><td style="text-align:right; vertical-align:top;">0      </td>          	<td style="text-align:right; vertical-align:top;"> 3FF<br/>WM_USER − 1</td>	<td>Reserved by the system (see detailed list below)</td></tr>
+<tr><td style="text-align:right; vertical-align:top;">400 <br/>WM_USER</td> 	<td style="text-align:right; vertical-align:top;">7FFF​</td>               	<td>Integer messages for use by private window classes<br/>(<strong>conflict</strong> with system messages)</td></tr>
+<tr><td style="text-align:right; vertical-align:top;">8000 <br/>WM_APP </td>	<td style="text-align:right; vertical-align:top;">BFFF​</td>               	<td>Messages available for use by apps<br/>(<strong>no</strong> conflict with system messages)</td></tr>
+<tr><td style="text-align:right; vertical-align:top;">C000 </td>            	<td style="text-align:right; vertical-align:top;">FFFF</td>                	<td>String messages for use by apps<br/>defined at runtime via RegisterWindowMessage</td></tr>
+<tr><td style="text-align:right; vertical-align:top;">10000</td>            	<td style="text-align:right; vertical-align:top;">∞</td>                   	<td>Reserved by the system</td></tr>
+</tbody>
+</table>
+For more details see <a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues#application-defined-messages">Application defined messages</a>,
+<a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-user#remarks">WM User</a>, and
+<a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-app#remarks">WM App</a>
+
 <h1>List of Windows Messages</h1>
 
 <p>Below is a list of some values for the <em>MsgNumber</em> parameter of <a href="../lib/PostMessage.htm">PostMessage</a>, <a href="../lib/SendMessage.htm">SendMessage</a>, and <a href="../lib/OnMessage.htm">OnMessage</a>. To discover more about how to use a particular message (e.g. <span class="code">WM_VSCROLL</span>), look it up at <a href="https://learn.microsoft.com/docs/">Microsoft Docs</a> or with a search engine of your choice. Also, check out the <a href="SendMessage.htm">Message Tutorial</a>.</p>


### PR DESCRIPTION
<body>
<h1>Ranges of Windows Message numbers</h1>
<p>Below is a summary table of values for the <em>MsgNumber</em> parameter of <a href="../lib/PostMessage.htm">PostMessage</a>, <a href="../lib/SendMessage.htm">SendMessage</a>, and <a href="../lib/OnMessage.htm">OnMessage</a>.</p>
<table><thead><tr><th>Min<br/>0 x Hex</th><th>Max<br/>0 x Hex</th><th>Meaning</th></tr></thead>
<tbody>
<tr><td style="text-align:right; vertical-align:top;">0      </td>          	<td style="text-align:right; vertical-align:top;"> 3FF<br/>WM_USER − 1</td>	<td>Reserved by the system (see detailed list below)</td></tr>
<tr><td style="text-align:right; vertical-align:top;">400 <br/>WM_USER</td> 	<td style="text-align:right; vertical-align:top;">7FFF​</td>               	<td>Integer messages for use by private window classes<br/>(<strong>conflict</strong> with system messages)</td></tr>
<tr><td style="text-align:right; vertical-align:top;">8000 <br/>WM_APP </td>	<td style="text-align:right; vertical-align:top;">BFFF​</td>               	<td>Messages available for use by apps<br/>(<strong>no</strong> conflict with system messages)</td></tr>
<tr><td style="text-align:right; vertical-align:top;">C000 </td>            	<td style="text-align:right; vertical-align:top;">FFFF</td>                	<td>String messages for use by apps<br/>defined at runtime via RegisterWindowMessage</td></tr>
<tr><td style="text-align:right; vertical-align:top;">10000</td>            	<td style="text-align:right; vertical-align:top;">∞</td>                   	<td>Reserved by the system</td></tr>
</tbody>
</table>
For more details see <a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/about-messages-and-message-queues#application-defined-messages">Application defined messages</a>,
<a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-user#remarks">WM User</a>, and
<a href="https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-app#remarks">WM App</a>
