### PR TITLE
Update WinGetList.htm

### DIFF
--- a/docs/lib/WinGetList.htm
+++ b/docs/lib/WinGetList.htm
@@ -22,7 +22,7 @@
     <dt>WinTitle, WinText, ExcludeTitle, ExcludeText</dt>
     <dd>
         <p>Type: <a href="../Concepts.htm#strings">String</a>, <a href="../Concepts.htm#numbers">Integer</a> or <a href="../Objects.htm">Object</a></p>
-        <p>If each of these is blank or omitted, the <a href="../misc/WinTitle.htm#LastFoundWindow">Last Found Window</a> will be used. Otherwise, specify for <em>WinTitle</em> a <a href="../misc/WinTitle.htm">window title or other criteria</a> to identify the target window and/or for <em>WinText</em> a substring from a single text element of the target window (as revealed by the included Window Spy utility). Hidden text elements are detected if <a href="DetectHiddenText.htm">DetectHiddenText</a> has been turned on. Windows whose title or text contains <em>ExcludeTitle</em> or <em>ExcludeText</em> will not be considered.</p>
+        <p>Specify for <em>WinTitle</em> a <a href="../misc/WinTitle.htm">window title or other criteria</a> to identify the target window and/or for <em>WinText</em> a substring from a single text element of the target window (as revealed by the included Window Spy utility). Hidden text elements are detected if <a href="DetectHiddenText.htm">DetectHiddenText</a> has been turned on. Windows whose title or text contains <em>ExcludeTitle</em> or <em>ExcludeText</em> will not be considered.</p>
     </dd>
 </dl>
 


### PR DESCRIPTION
Deleted sentence inconsistent with the function behavior and with the following statement in the [Remarks](https://www.autohotkey.com/docs/v2/lib/WinGetList.htm#Remarks) section:

> To retrieve all windows on the entire system, omit all four title/text parameters.