### PR TITLE
Update Functor.htm

### DIFF
--- a/docs/misc/Functor.htm
+++ b/docs/misc/Functor.htm
@@ -103,7 +103,7 @@ fn.Call(3) <em>; Shows "3, 1"</em>
 fn(, 4)    <em>; Error: 'a' was omitted</em>
 
 RealFn(a, b, c?) {
-    MsgBox a ", " b (IsSet(c) ? ", " : "")
+    MsgBox a ", " b (IsSet(c) ? ", " c : "")
 }</pre>
 <p><a href="../lib/ObjBindMethod.htm">ObjBindMethod</a> can be used to bind to a method even when it isn't possible to retrieve a reference to the method itself.  For example:</p>
 <pre>Shell := ComObject("Shell.Application")

--- a/docs/misc/Functor.htm
+++ b/docs/misc/Functor.htm
@@ -98,12 +98,12 @@ fn(2)      <em>; Shows "1, 2"</em>
 fn.Call(3) <em>; Shows "1, 3"</em>
 
 fn := RealFn.Bind( , 1)  <em>; Bind second parameter only</em>
-fn(2)      <em>; Shows "2, 1"</em>
+fn(2, 0)   <em>; Shows "2, 1, 0"</em>
 fn.Call(3) <em>; Shows "3, 1"</em>
 fn(, 4)    <em>; Error: 'a' was omitted</em>
 
-RealFn(a, b, c:="c") {
-    MsgBox a ", " b
+RealFn(a, b, c?) {
+    MsgBox a ", " b (IsSet(c) ? ", " : "")
 }</pre>
 <p><a href="../lib/ObjBindMethod.htm">ObjBindMethod</a> can be used to bind to a method even when it isn't possible to retrieve a reference to the method itself.  For example:</p>
 <pre>Shell := ComObject("Shell.Application")


### PR DESCRIPTION
I expanded the [BoundFunc Object](https://www.autohotkey.com/docs/v2/misc/Functor.htm#BoundFunc) example to demonstrate calling a BoundFunc object with the first and third parameter of `RealFn`. I had mistakenly tried to do so with `fn(2, , 0)`. This change could help others who are similarly confused.