### PR TITLE
Format's "width" spec controls length, not width

### DIFF
--- a/docs/lib/Format.htm
+++ b/docs/lib/Format.htm
@@ -48,7 +48,7 @@ MsgBox Format("{2:x}{1:02x}", arr*)</pre>
 <p>Each format specifier can include the following components, in this order (without the spaces):</p>
 <pre class="Syntax">Flags Width .Precision ULT Type</pre>
 <p><strong>Flags:</strong> Zero or more flags from the <a href="#Flags">flag table</a> below to affect output justification and prefixes.</p>
-<p><strong>Width:</strong> A decimal integer which controls the minimum width of the formatted value, in characters. By default, values are right-aligned and spaces are used for padding. This can be overridden by using the <code>-</code> (left-align) and <code class="no-highlight">0</code> (zero prefix) flags.</p>
+<p id="Width"><strong>Width:</strong> A decimal integer which controls the minimum number of characters of the formatted value. By default, values are right-aligned and spaces are used for padding. This can be overridden by using the <code>-</code> (left-align) and <code class="no-highlight">0</code> (zero prefix) flags.</p>
 <p><strong>.Precision:</strong> A decimal integer which controls the maximum number of string characters, decimal places, or significant digits to output, depending on the output type. It must be preceded by a decimal point. Specifying a precision may cause the value to be truncated or rounded. Output types and how each is affected by the precision value are as follows (see table below for an explanation of the different output types):</p>
 <ul>
   <li><code>f</code>, <code>e</code>, <code>E</code>: <em>Precision</em> specifies the number of digits after the decimal point. The default is 6.</li>
@@ -65,8 +65,8 @@ MsgBox Format("{2:x}{1:02x}", arr*)</pre>
   <tr>
     <td><code>-</code></td>
     <td>
-      <p>Left align the result within the given field width (insert spaces to the right if needed). For example, <code>Format("{:-10}", 1)</code> returns <code class="no-highlight" style="white-space: pre">1         </code>.</p>
-      <p>If omitted, the result is right aligned within the given field width.</p>
+      <p>Left align the result within the given field length (insert spaces to the right if needed). For example, <code>Format("{:-10}", 1)</code> returns <code class="no-highlight" style="white-space: pre">1         </code>.</p>
+      <p>If omitted, the result is right aligned within the given field length.</p>
     </td>
   </tr>
   <tr>
@@ -79,7 +79,7 @@ MsgBox Format("{2:x}{1:02x}", arr*)</pre>
   <tr>
     <td><code class="no-highlight">0</code></td>
     <td>
-      <p>If <em>width</em> is prefixed by 0, leading zeros are added until the minimum width is reached. For example, <code>Format("{:010}", 1)</code> returns <code class="no-highlight">0000000001</code>. If both <code class="no-highlight">0</code> and <code>-</code> appear, the 0 is ignored. If 0 is specified as an integer format (i, u, x, X, o, d) and a precision specification is also present - for example, <code class="no-highlight">{:04.d}</code> - the 0 is ignored.</p>
+      <p>If <em>width</em> is prefixed by 0, leading zeros are added until the minimum length is reached. For example, <code>Format("{:010}", 1)</code> returns <code class="no-highlight">0000000001</code>. If both <code class="no-highlight">0</code> and <code>-</code> appear, the 0 is ignored. If 0 is specified as an integer format (i, u, x, X, o, d) and a precision specification is also present - for example, <code class="no-highlight">{:04.d}</code> - the 0 is ignored.</p>
       <p>If omitted, no padding occurs.</p>
     </td>
   </tr>
@@ -178,6 +178,7 @@ MsgBox Format("{2:x}{1:02x}", arr*)</pre>
 
 <h2 id="Remarks">Remarks</h2>
 <p>Unlike <a href="https://learn.microsoft.com/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions">printf</a>, size specifiers are not supported. All integers and floating-point input values are 64-bit.</p>
+<p>Despite its name, the <a href="#Width">Width</a> specifier does not control the width. It controls the number of characters. If <a href="https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms">fullwidth</a> characters like emojis are involved, you cannot control the width even with monospaced fonts.</p>
 
 <h2 id="Related">Related</h2>
 <p><a href="FormatTime.htm">FormatTime</a></p>


### PR DESCRIPTION
It is really hard to calculate characters' width. (See how long https://github.com/microsoft/terminal/issues/900 is.)

If Format() really accepted width, I would expect that Format("{:2}", "😀") returns "😀" (only a smile) instead of " 😀" (a space and a smile).

Microsoft doesn't say their printf calculates the width:
https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions.md#width

We too could use technically correct words like "the minimum number of characters"