### PR TITLE
Clarify that FileDelete permanently deletes

### DIFF
--- a/docs/lib/FileDelete.htm
+++ b/docs/lib/FileDelete.htm
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <title>FileDelete - Syntax &amp; Usage | AutoHotkey v2</title>
-<meta name="description" content="The FileDelete function deletes one or more files." />
+<meta name="description" content="The FileDelete function permanently deletes one or more files." />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <link href="../static/theme.css" rel="stylesheet" type="text/css" />

--- a/docs/lib/FileDelete.htm
+++ b/docs/lib/FileDelete.htm
@@ -32,6 +32,7 @@
 <p>If files were found, <a href="../Variables.htm#LastError">A_LastError</a> is set to 0 (zero) or the result of the operating system's GetLastError() function immediately after the last failure. Otherwise A_LastError contains an error code that might indicate why no files were found.</p>
 
 <h2 id="Remarks">Remarks</h2>
+<p>To send a file to the recycle bin, use the <a href="FileRecycle.htm">FileRecycle</a> function.</p>
 <p>To delete a read-only file, first remove the read-only attribute. For example: <code><a href="FileSetAttrib.htm">FileSetAttrib</a> "-R", "C:\My File.txt"</code>.</p>
 <h2 id="Related">Related</h2>
 <p><a href="FileRecycle.htm">FileRecycle</a>, <a href="DirDelete.htm">DirDelete</a>, <a href="FileCopy.htm">FileCopy</a>, <a href="FileMove.htm">FileMove</a></p>

--- a/docs/lib/FileDelete.htm
+++ b/docs/lib/FileDelete.htm
@@ -12,7 +12,7 @@
 
 <h1>FileDelete</h1>
 
-<p>Deletes one or more files.</p>
+<p>Permanently deletes one or more files.</p>
 
 <pre class="Syntax"><span class="func">FileDelete</span> FilePattern</pre>
 <h2 id="Parameters">Parameters</h2>


### PR DESCRIPTION
I used FileDelete and thought the file would go to the recycle bin. I only learned that FileDelete permanently deleted the file when I learned FileRecycle existed.

FileRecycle mentions that it may permanently delete the file if it's not possible to recycle, yet FileDelete has no mention of the word permanent.

Clarifying this will prevent a lot of people from making the same mistake.