### PR TITLE
Mention uiaccess

### DIFF
--- a/docs/lib/WinSetAlwaysOnTop.htm
+++ b/docs/lib/WinSetAlwaysOnTop.htm
@@ -43,6 +43,7 @@
 <p>An <a href="Error.htm#OSError">OSError</a> may be thrown on failure.</p>
 
 <h2 id="Remarks">Remarks</h2>
+<p>WinSetAlwaysOnTop and <a href="WinMoveTop.htm">WinMoveTop</a> usually bring the window to the top. But windows without <a href="Program.htm#Installer_uiAccess">UIAccess</a> can not appear on top of always-on-top UWP apps such as full-screen playback of Movies&amp;TV.</p>
 <p>The ID of the window under the mouse cursor can be retrieved with <a href="MouseGetPos.htm">MouseGetPos</a>.</p>
 
 <h2 id="Related">Related</h2>


### PR DESCRIPTION
If there is an always-on-top UWP window, you need UIAccess to make another window *really*-always-on-top.

For example, run [Movies&TV](https://apps.microsoft.com/detail/9wzdncrfj3p2) (UWP app) in full-screen mode on one monitor. It is always-on-top.
Then move another always-on-top window (of AHK or anything) from another monitor to Movies&TV. It won't appear on top, *even with admin privs*, if it doesn't have UIAccess.

Neither WinSetAlwaysOnTop nor WinMoveTop can bring it up to the top of such UWP windows without UIAccess. Only UIAccess helps in this case.

https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-securityoverview says
> an assistive technology application with these privileges can run as the topmost application in the z-order at any time, meaning that an assistive technology application can be visible and available whenever the user needs it.