### PR TITLE
Advise not to make off-by-one errors

### DIFF
--- a/docs/lib/MonitorGet.htm
+++ b/docs/lib/MonitorGet.htm
@@ -43,6 +43,7 @@
 <p>The built-in variables <a href="../Variables.htm#Screen">A_ScreenWidth</a> and <a href="../Variables.htm#Screen">A_ScreenHeight</a> contain the dimensions of the primary monitor, in pixels.</p>
 <p><a href="SysGet.htm">SysGet</a> can be used to retrieve the bounding rectangle of all display monitors. For example, this retrieves the width and height of the virtual screen:</p>
 <pre>MsgBox SysGet(78) " x " SysGet(79)</pre>
+<p>Note that (Right, Bottom) is not on the monitor, while (Left, Top) is. The bottom right pixel of the monitor is (Right - 1, Bottom - 1).</p>
 
 <h2 id="Related">Related</h2>
 <p><a href="MonitorGetWorkArea.htm">MonitorGetWorkArea</a>, <a href="SysGet.htm">SysGet</a>, <a href="Monitor.htm">Monitor functions</a></p>


### PR DESCRIPTION
Though you can use (Top, Left) as the upper-left pixel, you cannot use Bottom or Right as the maximum value within the monitor.
![image](https://github.com/AutoHotkey/AutoHotkeyDocs/assets/383537/fc9f1c1c-444a-4816-9939-b254c7fcccac)
