### PR TITLE
Update Gui.htm

### DIFF
--- a/docs/lib/Gui.htm
+++ b/docs/lib/Gui.htm
@@ -341,7 +341,7 @@ MyGui.Move(x-10,, w+20)</pre>
   </ul>
   <p id="LastFound"><strong>LastFound:</strong> Sets the window to be the <a href="../misc/WinTitle.htm#LastFoundWindow">last found window</a> (though this is unnecessary in a <a href="GuiOnEvent.htm#Threads">GUI thread</a> because it is done automatically), which allows functions such as <a href="WinGetStyle.htm">WinGetStyle</a> and <a href="WinSetTransparent.htm">WinSetTransparent</a> to operate on it even if it is hidden (that is, <a href="DetectHiddenWindows.htm">DetectHiddenWindows</a> is not necessary). This is especially useful for changing the properties of the window before showing it. For example:</p>
   <pre>MyGui.Opt("+LastFound")
-WinSetTransColor(CustomColor " 150", MyGui)
+WinSetTransColor(CustomColor " 150")
 MyGui.Show()</pre>
   <p id="MaximizeBox"><strong>MaximizeBox:</strong> Enables the maximize button in the title bar. This is also included as part of <em>Resize</em> below.</p>
   <p id="MinimizeBox"><strong>MinimizeBox</strong> (present by default): Enables the minimize button in the title bar.</p>


### PR DESCRIPTION
As currently implemented in the documentation page, the example works but fails to demonstrate the value of setting the window to be the last found window. If the last found window is set, the second parameter in the `WinSetTransColor` is not necessary.

Below is a test script for reference.

```AutoHotkey
#Requires AutoHotkey v2.0

CustomColor := 'Red'

MyGui := Gui()
MyGui.MarginX := MyGui.MarginY := 0
MyGui.Add('Progress', 'w150 h300 c' CustomColor, 100)
MyGui.Add('Progress', 'x+0 yp w150 h300 cBlue', 100)
MyGui.Show()

F3::
{
   MsgBox WinExist() '`n' MyGui.Hwnd
   MyGui.Opt("+LastFound")  ; Sets MyGui as the last found window.
   WinSetTransColor(CustomColor " 150")
   ; WinSetTransColor(CustomColor " 150", MyGui)
   MsgBox WinExist() '`n' MyGui.Hwnd
}