### PR TITLE
Clarify which thread in Pause param description

### DIFF
--- a/docs/lib/Pause.htm
+++ b/docs/lib/Pause.htm
@@ -24,7 +24,7 @@
   <dd>
     <p>Type: <a href="../Concepts.htm#numbers">Integer</a></p>
     <p>If omitted, the <a href="../misc/Threads.htm">current thread</a> is paused. Otherwise, specify one of the following values:</p>
-    <p><code>1</code> or <code>True</code>: Marks the underlying thread as paused. The current thread is not paused and continues running. When it finishes, the underlying thread resumes any interrupted function the underlying thread was running. Once the underlying thread finishes the function (if any), it enters a paused state. If there is no thread underneath the current thread, the script itself is paused, which prevents <a href="SetTimer.htm">timers</a> from running (this effect is the same as having used the menu item "Pause Script" while the script has no threads).</p>
+    <p><code>1</code> or <code>True</code>: Marks the underlying thread as paused. The current thread is not paused and continues running. When the current thread finishes, the underlying thread resumes any interrupted function the underlying thread was running. Once the underlying thread finishes the function (if any), it enters a paused state. If there is no thread underneath the current thread, the script itself is paused, which prevents <a href="SetTimer.htm">timers</a> from running (this effect is the same as having used the menu item "Pause Script" while the script has no threads).</p>
     <p><code>0</code> or <code>False</code>: Unpauses the underlying thread.</p>
     <p><code>-1</code>: Toggles the pause state of the underlying thread.</p>
   </dd>


### PR DESCRIPTION
This is a very minor edit to 028b052.  I've changed the previous
> Marks the underlying thread as paused. The current thread is not paused and continues running. When it finishes, the underlying thread resumes...

to

> Marks the underlying thread as paused. The current thread is not paused and continues running. When the current thread finishes, the underlying thread resumes...

With the old description, I had to think for a moment about which thread "it" was referring to because "the underlying thread" is in the same sentence. Again, due to the nuance of threads, we have to be careful when using pronouns.