### PR TITLE
Update ControlSetText.htm

### DIFF
--- a/docs/lib/ControlSetText.htm
+++ b/docs/lib/ControlSetText.htm
@@ -21,7 +21,7 @@
   <dt>NewText</dt>
   <dd>
     <p>Type: <a href="../Concepts.htm#strings">String</a></p>
-    <p>If blank or omitted, the control is made blank. Otherwise, specify the new text to set into the control.</p>
+    <p>If blank, the control is made blank. Otherwise, specify the new text to set into the control.</p>
   </dd>
 
   <dt>Control</dt>


### PR DESCRIPTION
The `NewText` parameter is required. [[Source Code Reference](https://github.com/AutoHotkey/AutoHotkey/blob/581114c1c7bb3890ff61cf5f6e1f1201cd8c8b78/source/lib/win.cpp#L829)]

The following code, intended to blank the output pane of a SciTe4AutoHotkey window, fails:

`ControlSetText , 'Scintilla2', 'A'`

The following code works:

`ControlSetText '', 'Scintilla2', 'A'`
