### PR TITLE
Update CoordMode.htm

### DIFF
--- a/docs/lib/CoordMode.htm
+++ b/docs/lib/CoordMode.htm
@@ -12,7 +12,7 @@
 
 <h1>CoordMode</h1>
 
-<p>Sets coordinate mode for various built-in functions to be relative to either the active window or the screen.</p>
+<p>Sets coordinate mode for various built-in functions to be relative to either the active window or the screen. <em>Client</em> is the default CoordMode if not changed in your script.</p>
 
 <pre class="Syntax"><span class="func">CoordMode</span> TargetType <span class="optional">, RelativeTo</span></pre>
 <h2 id="Parameters">Parameters</h2>
@@ -32,7 +32,7 @@
   <dt>RelativeTo</dt>
   <dd>
       <p>Type: <a href="../Concepts.htm#strings">String</a></p>
-      <p>If omitted, it defaults to <em>Screen</em>. Otherwise, specify one of the following words to indicate the area to which <em>TargetType</em> should be relative:</p>
+      <p>If this parameter is omitted, it defaults to <em>Screen</em>. Otherwise, specify one of the following words to indicate the area to which <em>TargetType</em> should be relative:</p>
       <p><strong>Screen:</strong> Coordinates are relative to the desktop (entire screen).</p>
       <p><strong>Window:</strong> Coordinates are relative to the active window.</p>
       <p id="Client"><strong>Client:</strong> Coordinates are relative to the active window's client area, which excludes the window's title bar, menu (if it has a standard one) and borders.  Client coordinates are less dependent on OS version and theme.</p>


### PR DESCRIPTION
Clarify what the default value is when CoordMode is never used in the documentation, because it could be missed if the person reading doesnt get to the Remarks area.