### PR TITLE
Update WinWait.htm

### DIFF
--- a/docs/lib/WinWait.htm
+++ b/docs/lib/WinWait.htm
@@ -14,7 +14,7 @@
 
 <p>Waits until the specified window exists.</p>
 
-<pre class="Syntax"><span class="func">WinWait</span> <span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span></pre>
+<pre class="Syntax">HWND := <span class="func">WinWait</span>(<span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span>)</pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
Changed syntax to reflect that `WinWait` returns returns the [HWND (unique ID)](https://www.autohotkey.com/docs/v2/misc/WinTitle.htm#ahk_id) of a matching window if one was found.
