### PR TITLE
Update WinWaitActive.htm

### DIFF
--- a/docs/lib/WinWaitActive.htm
+++ b/docs/lib/WinWaitActive.htm
@@ -14,8 +14,8 @@
 
 <p>Waits until the specified window is active or not active.</p>
 
-<pre class="Syntax"><span class="func">WinWaitActive</span> <span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span>
-<span class="func">WinWaitNotActive</span> <span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span></pre>
+<pre class="Syntax">HWND := <span class="func">WinWaitActive</span>(<span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span>)
+Boolean := <span class="func">WinWaitNotActive</span>(<span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span>)</pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
Changed syntax to reflect that:

1. `WinWaitActive` returns the [HWND (unique ID)](https://www.autohotkey.com/docs/v2/misc/WinTitle.htm#ahk_id) of a matching window if one was found, and
2.  `WinWaitNotActive` returns a boolean value reflecting whether the active window matches the criteria or not.