### PR TITLE
Update WinWaitClose.htm

### DIFF
--- a/docs/lib/WinWaitClose.htm
+++ b/docs/lib/WinWaitClose.htm
@@ -14,7 +14,7 @@
 
 <p>Waits until no matching windows can be found.</p>
 
-<pre class="Syntax"><span class="func">WinWaitClose</span> <span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span></pre>
+<pre class="Syntax">Boolean := <span class="func">WinWaitClose</span>(<span class="optional">WinTitle, WinText, Timeout, ExcludeTitle, ExcludeText</span>)</pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
Changed syntax to reflect that `WinWaitClose` returns a boolean value reflecting whether the function timed out or not.