### PR TITLE
Update ClipWait.htm

### DIFF
--- a/docs/lib/ClipWait.htm
+++ b/docs/lib/ClipWait.htm
@@ -14,7 +14,7 @@
 
 <p>Waits until the <a href="A_Clipboard.htm">clipboard</a> contains data.</p>
 
-<pre class="Syntax"><span class="func">ClipWait</span> <span class="optional">Timeout, WaitFor</span></pre>
+<pre class="Syntax">Boolean := <span class="func">ClipWait</span>(<span class="optional">Timeout, WaitFor</span>)</pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
Changed syntax to reflect that `ClipWait` returns a boolean value reflecting whether the function timed out or not.