### PR TITLE
fix dllcall com example

### DIFF
--- a/docs/lib/DllCall.htm
+++ b/docs/lib/DllCall.htm
@@ -454,8 +454,7 @@ DllCall(vtable(tbl.ptr,5), "ptr", tbl, "ptr", activeHwnd)  <em>; tbl.<a href="ht
 Sleep 3000
 DllCall(vtable(tbl.ptr,4), "ptr", tbl, "ptr", activeHwnd)  <em>; tbl.<a href="https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-itaskbarlist-addtab">AddTab</a>(activeHwnd)</em>
 
-<em>; Non-wrapped interface pointers must be manually freed.</em>
-ObjRelease(tbl.ptr)
+<em>; Interface pointer will be freed automatically.</em>
 
 vtable(ptr, n) {
     <em>; NumGet(ptr, "ptr") returns the address of the object's virtual function


### PR DESCRIPTION
VT_UNKNOWN pointer will be released automatically in this case.