### PR TITLE
Update CallbackCreate.htm

### DIFF
--- a/docs/lib/CallbackCreate.htm
+++ b/docs/lib/CallbackCreate.htm
@@ -156,6 +156,7 @@ WindowProc(hwnd, uMsg, wParam, lParam)
     if (uMsg = 0x0138 &amp;&amp; lParam = Text.Hwnd)  <em>; 0x0138 is WM_CTLCOLORSTATIC.</em>
     {
         DllCall("SetBkColor", "Ptr", wParam, "UInt", TextBackgroundColor)
+        DllCall(SetWindowLong, "Ptr", MyGui.Hwnd, "Int", -4, "Ptr", WindowProcOld, "Ptr")  ; Remove the subclass from the control.
         return TextBackgroundBrush  <em>; Return the HBRUSH to notify the OS that we altered the HDC.</em>
     }
     <em>; Otherwise (since above didn't return), pass all unhandled events to the original WindowProc.</em>

--- a/docs/lib/CallbackCreate.htm
+++ b/docs/lib/CallbackCreate.htm
@@ -149,6 +149,8 @@ WindowProcOld := DllCall(SetWindowLong, "Ptr", MyGui.Hwnd, "Int", -4  <em>; -4 i
     , "Ptr", WindowProcNew, "Ptr") <em>; Return value must be set to "Ptr" or "UPtr" vs. "Int".</em>
 
 MyGui.Show()
+DllCall(SetWindowLong, "Ptr", MyGui.Hwnd, "Int", -4, "Ptr", WindowProcOld)  <em>; Remove the subclass from the control.</em>
+DllCall("DeleteObject", "Ptr", TextBackgroundBrush)
 
 WindowProc(hwnd, uMsg, wParam, lParam)
 {
@@ -156,7 +158,6 @@ WindowProc(hwnd, uMsg, wParam, lParam)
     if (uMsg = 0x0138 &amp;&amp; lParam = Text.Hwnd)  <em>; 0x0138 is WM_CTLCOLORSTATIC.</em>
     {
         DllCall("SetBkColor", "Ptr", wParam, "UInt", TextBackgroundColor)
-        DllCall(SetWindowLong, "Ptr", MyGui.Hwnd, "Int", -4, "Ptr", WindowProcOld, "Ptr")  ; Remove the subclass from the control.
         return TextBackgroundBrush  <em>; Return the HBRUSH to notify the OS that we altered the HDC.</em>
     }
     <em>; Otherwise (since above didn't return), pass all unhandled events to the original WindowProc.</em>


### PR DESCRIPTION
Added a line to Example # 2 to remove the subclass from the control. Doing so prevents the function from having to process further messages [[Reference](https://learn.microsoft.com/en-us/windows/win32/winmsg/using-window-procedures#subclassing-a-window)].