### PR TITLE
Update A_MaxHotkeysPerInterval.htm

### DIFF
--- a/docs/lib/A_MaxHotkeysPerInterval.htm
+++ b/docs/lib/A_MaxHotkeysPerInterval.htm
@@ -16,7 +16,7 @@
 <p><em>A_MaxHotkeysPerInterval</em> and <em>A_HotkeyInterval</em> are <a href="../Concepts.htm#built-in-variables">built-in variables</a> that control the rate of <a href="../Hotkeys.htm">hotkey</a> activations beyond which a warning dialog will be displayed.</p>
 <p><em>A_MaxHotkeysPerInterval</em> can be used to get or set an <a href="../Concepts.htm#numbers">integer</a> representing the maximum number of hotkeys that can be pressed within the interval without triggering a warning dialog.</p>
 <p><em>A_HotkeyInterval</em> can be used to get or set an <a href="../Concepts.htm#numbers">integer</a> representing the length of the interval in milliseconds.</p>
-<p>The default settings are 70 (ms) for <em>A_MaxHotkeysPerInterval</em> and 2000 (ms) for <em>A_HotkeyInterval</em>.</p>
+<p>The default settings are 70 for <em>A_MaxHotkeysPerInterval</em> and 2000 (ms) for <em>A_HotkeyInterval</em>.</p>
 
 <h2 id="Remarks">Remarks</h2>
 <p>These built-in variables should usually be assigned values when the script starts (if the default settings are not suitable), but the script can get or set their values at any time.</p>


### PR DESCRIPTION
Replace "70 (ms)" with "70" in 
"The default settings are 70 (ms) for <em>A_MaxHotkeysPerInterval</em> and 2000 (ms) for <em>A_HotkeyInterval</em>."