### PR TITLE
Update ControlGetStyle.htm

### DIFF
--- a/docs/lib/ControlGetStyle.htm
+++ b/docs/lib/ControlGetStyle.htm
@@ -39,7 +39,8 @@ ExStyle := <span class="func">ControlGetExStyle</span>(Control <span class="opti
 <p>These functions return the style or extended style of the specified control.</p>
 
 <h2 id="Error_Handling">Error Handling</h2>
-<p>A <a href="Error.htm#TargetError">TargetError</a> is thrown if the window or control could not be found.</p>
+<p>A <a href="Error.htm#TargetError">TargetError</a> is thrown if the window or control could not be found. For the extended style of <a href="../lib/ListView.htm">ListView</a> controls, use the following:</p>
+<pre><a href="SendMessage.htm">SendMessage</a>(0x1037, 0, 0, LV)  <em>; 0x1037 is LVM_GETEXTENDEDLISTVIEWSTYLE</em></pre>
 
 <h2 id="Remarks">Remarks</h2>
 <p>See the <a href="../misc/Styles.htm">styles table</a> for a partial listing of styles.</p>


### PR DESCRIPTION
Added approach to getting the extended style for ListView controls as the built-in function (ControlGetExStyle) doesn't produce the correct result. See the code below.

``` ahk
#Requires AutoHotkey v2.0

MyGui := Gui()
LVS_EX_INFOTIP := 0x00000400
LV := MyGui.Add('ListView', Format('w{} r{} LV{} Grid', 300, 10, LVS_EX_INFOTIP), ['Column 1', 'Column 2', 'Column 3'])
Loop 10
   LV.Add('', A_Index, A_ScriptName, A_ScriptFullPath)
MyGui.Show()

MsgBox Format('0x{:X}', LV_GetExStyle(LV)) '`n'
     . Format('0x{:X}', ControlGetExStyle(LV)) '`n'
     . Format('0x{:X}', DllCall('GetWindowLongPtr', 'Ptr', LV.Hwnd, 'Int', GWL_EXSTYLE := -20, 'UPtr'))

LV_GetExStyle(LV) {
   static LVM_GETEXTENDEDLISTVIEWSTYLE := 0x00001037
   return SendMessage(LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0, LV)
}