### PR TITLE
Refactor Word.Application example with try-catch

### DIFF
--- a/docs/lib/ComObjActive.htm
+++ b/docs/lib/ComObjActive.htm
@@ -40,11 +40,15 @@
 <div class="ex" id="ExWord">
 <p><a class="ex_number" href="#ExWord"></a> Displays the active document in Microsoft Word, if it is running. For details about the COM object and its properties used below, see <a href="https://learn.microsoft.com/office/vba/api/Word.Application">Word.Application object (Microsoft Docs)</a>.</p>
 <pre>
-word := ComObjActive("Word.Application")
-if !word
-    MsgBox "Word isn't open."
-else
-    MsgBox word.ActiveDocument.FullName</pre>
+  try {
+	word := ComObjActive("Word.Application")
+	MsgBox word.ActiveDocument.FullName
+} catch {
+	MsgBox "Word isn't open."
+} finally {
+	word :=  ""
+}
+</pre>
 </div>
 
 </body>


### PR DESCRIPTION
Original v1 example is not valid in v2 because we get an error when the ComObjActive function cannot create the object.