### PR TITLE
Update error handling description for objects

### DIFF
--- a/docs/Concepts.htm
+++ b/docs/Concepts.htm
@@ -106,7 +106,7 @@ Exception handling
   <li>Two object references compare equal only if they refer to the same object.</li>
   <li>Objects are always considered <i>true</i> when a boolean value is required, such as in <code>if obj</code>, <code>!obj</code> or <code>obj ? x : y</code>.</li>
   <li>Each object has a unique address (location in memory), which can be retrieved by the <a href="Objects.htm#ObjPtr">ObjPtr</a> function, but is typically not used directly. This address uniquely identifies the object, but only until the object is freed.</li>
-  <li>In some cases when an object is used in a context where one was not expected, it might be treated as an empty string. For example, <code>MsgBox(myObject)</code> shows an empty MsgBox. In other cases, a <a href="lib/Error.htm#TypeError">TypeError</a> may be thrown (and this should become the norm in future).</li>
+  <li>In some cases when an object is used in a context where one was not expected, a <a href="lib/Error.htm#TypeError">TypeError</a> is thrown</li>
 </ul>
 <p class="note"><strong>Note:</strong> All objects which derive from <a href="lib/Object.htm">Object</a> have additional shared behaviour, properties and methods.</p>
 <p>Some ways that objects are used include:</p>


### PR DESCRIPTION
The original text is outdated. Errors are thrown if an object is used in  a context that doesnt accept objects.