### PR TITLE
Update StatusBarWait.htm

### DIFF
--- a/docs/lib/StatusBarWait.htm
+++ b/docs/lib/StatusBarWait.htm
@@ -15,7 +15,7 @@
 
 <p>Waits until a window's status bar contains the specified string.</p>
 
-<pre class="Syntax"><span class="func">StatusBarWait</span> <span class="optional">BarText, Timeout, Part#, WinTitle, WinText, Interval, ExcludeTitle, ExcludeText</span></pre>
+<pre class="Syntax">Boolean := <span class="func">StatusBarWait</span>(<span class="optional">BarText, Timeout, Part#, WinTitle, WinText, Interval, ExcludeTitle, ExcludeText</span></pre>)
 <h2 id="Parameters">Parameters</h2>
 <dl>
 
@@ -91,7 +91,7 @@
 if WinExist("A")  <em>; Set the last-found window to be the active window (for use below).</em>
 {
     OrigText := StatusBarGetText()
-    StatusBarWait "^(?!^\Q" OrigText "\E$)"  <em>; This regular expression waits for any change to the text.</em>
+    StatusBarWait "^(?!\Q" OrigText "\E$)"  <em>; This regular expression waits for any change to the text.</em>
 }</pre>
 </div>
 

--- a/docs/lib/StatusBarWait.htm
+++ b/docs/lib/StatusBarWait.htm
@@ -15,7 +15,7 @@
 
 <p>Waits until a window's status bar contains the specified string.</p>
 
-<pre class="Syntax">Boolean := <span class="func">StatusBarWait</span>(<span class="optional">BarText, Timeout, Part#, WinTitle, WinText, Interval, ExcludeTitle, ExcludeText</span></pre>)
+<pre class="Syntax">Boolean := <span class="func">StatusBarWait</span>(<span class="optional">BarText, Timeout, Part#, WinTitle, WinText, Interval, ExcludeTitle, ExcludeText</span>)</pre>
 <h2 id="Parameters">Parameters</h2>
 <dl>
 


### PR DESCRIPTION
- Changed the syntax to reflect the fact that the function returns a boolean value.
- Removed extraneous `^` character from the RegEx string in [Example #2](https://www.autohotkey.com/docs/v2/lib/StatusBarWait.htm#ExChange).

Tested with the following script:

```
MyGui := Gui()
MySB := MyGui.Add('StatusBar', , 'Starting text')
MyGui.Show('w200 h100')
MyGui.OnEvent('Close', (*) => ExitApp())

SetTitleMatchMode "RegEx"  ; Accept regular expressions for use below.
if WinExist("A")  ; Set the last-found window to be the active window (for use below).
{
    OrigText := StatusBarGetText()
    MsgBox StatusBarWait("^(?!\Q" OrigText "\E$)")  ; This regular expression waits for any change to the text.
}

F3::MySB.SetText("Starting")
```